### PR TITLE
improvement(clickable link) detect and convert links in chat messages…

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 
 import { useNavigate, Link } from "react-router-dom";
 import { getNow, cn } from "@/lib/utils";
+import { linkify } from "@/lib/linkify";
 
 interface PostCardProps {
   post: PostWithProfile;
@@ -119,7 +120,9 @@ const PostCard = ({ post, onLike, onBookmark, onDelete }: PostCardProps) => {
             )}
           </div>
 
-          <p className="mt-2 text-sm leading-relaxed whitespace-pre-wrap">{post.content}</p>
+          <p className="mt-2 text-sm leading-relaxed whitespace-pre-wrap">
+            {linkify(post.content)}
+          </p>
 
           {post.media_url && (
             <div className="mt-3 rounded-lg gum-border overflow-hidden bg-muted">

--- a/src/lib/linkify.tsx
+++ b/src/lib/linkify.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+const urlRegex = /(https?:\/\/[^\s]+)/g;
+
+export function linkify(text: string) {
+    return text.split(urlRegex).map((part, i) =>
+        urlRegex.test(part) ? (
+            <a
+                key={i}
+                href={part}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-500 underline hover:text-blue-600"
+            >
+                {part}
+            </a>
+        ) : (
+            part
+        )
+    );
+}

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -8,6 +8,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { useAuth } from "@/hooks/useAuth";
 import { toast } from "sonner";
 import { Helmet } from "react-helmet-async";
+import { linkify } from "@/lib/linkify";
 
 const ChatPage = () => {
     const { username } = useParams<{ username: string }>();
@@ -82,6 +83,7 @@ const ChatPage = () => {
 
     if (!targetProfile) return null;
 
+
     return (
         <div className="h-[100svh] bg-background text-foreground flex flex-col overflow-hidden">
             <Helmet>
@@ -136,8 +138,9 @@ const ChatPage = () => {
                                     ? "bg-primary text-primary-foreground border-primary"
                                     : "bg-secondary text-secondary-foreground border-border"
                                     }`}>
-                                    <p className="whitespace-pre-wrap break-words">{whisper.content}</p>
-                                    <span className={`text-[9px] mt-1.5 block font-mono opacity-60 ${isMe ? "text-primary-foreground/70" : "text-muted-foreground"}`}>
+                                    <p className="whitespace-pre-wrap break-words">
+                                        {linkify(whisper.content)}
+                                    </p>                                    <span className={`text-[9px] mt-1.5 block font-mono opacity-60 ${isMe ? "text-primary-foreground/70" : "text-muted-foreground"}`}>
                                         {new Date(whisper.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                                     </span>
                                 </div>

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -11,6 +11,8 @@ import { toast } from "sonner";
 import { Helmet } from "react-helmet-async";
 import { formatDistanceToNow } from "date-fns";
 import { usePostActions } from "@/hooks/usePostActions";
+import { linkify } from "@/lib/linkify";
+
 
 const PostPage = () => {
     const { postId } = useParams<{ postId: string }>();
@@ -364,7 +366,8 @@ const PostPage = () => {
                                                                     </div>
                                                                 )}
                                                             </div>
-                                                            <p className="text-sm whitespace-pre-wrap">{comment.content}</p>
+                                                            <p className="text-sm whitespace-pre-wrap">
+                                                                {linkify(comment.content)}                                                            </p>
                                                         </div>
                                                     </div>
                                                 </div>


### PR DESCRIPTION
### What this PR does
- Detects URLs in chat messages.
- Converts detected URLs into clickable links (<a> tags).
- Added `linkify` utility function in `src/lib/linkify.tsx`.

### Screenshots

### How to test
post a link anywhere comment/post/msg
<img width="389" height="105" alt="Screenshot 2026-03-05 155405" src="https://github.com/user-attachments/assets/4cc65942-92a0-4a77-ab47-06d47f1499be" />
<img width="827" height="268" alt="Screenshot 2026-03-05 155337" src="https://github.com/user-attachments/assets/673d4d28-c88e-468c-8ccb-f6029eb760b5" />
<img width="853" height="120" alt="Screenshot 2026-03-05 155348" src="https://github.com/user-attachments/assets/47020267-db41-4a73-829b-ff65c7855fdb" />
