### PR TITLE
feat: add web push notifications via Supabase Edge Function

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,12 @@ VITE_ADMIN_EMAILS="email1@example.com,email2@example.com"
 VITE_SENTRY_DSN=""
 
 
+# ── Push Notifications (VAPID) ──────────────────────────────
+# Public VAPID key for Web Push API subscriptions.
+# The private key must be set in Supabase Edge Function env vars (never expose it here).
+VITE_VAPID_PUBLIC_KEY="BHr3-0PCvg8CO5gsel4wr6DxXEn1QoS3x0OhNiTjAQq-gihRo69ZjQQqTQJkKKqmkQdLJM_j4ypTN4DiK7QJySw"
+
+
 # ── Cloudflare Worker (Production only) ───────────────────────
 # In production, all secrets above are served by a Cloudflare Worker.
 # Set this in Vercel environment variables — NOT needed locally.

--- a/cloudflare-worker/index.js
+++ b/cloudflare-worker/index.js
@@ -34,6 +34,7 @@ export default {
         VITE_ADMIN_EMAILS: env.VITE_ADMIN_EMAILS,
         VITE_LANG_SERVICE: env.VITE_LANG_SERVICE,
         VITE_SENTRY_DSN: env.VITE_SENTRY_DSN,
+        VITE_VAPID_PUBLIC_KEY: env.VAPID_PUBLIC_KEY,
       };
 
       return new Response(JSON.stringify(config), {

--- a/src/hooks/usePushNotifications.ts
+++ b/src/hooks/usePushNotifications.ts
@@ -1,0 +1,172 @@
+import { useState, useEffect, useCallback } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/hooks/useAuth";
+import { getConfig } from "@/lib/config";
+
+const PUSH_ENABLED_KEY = "genjutsu-push-enabled";
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; i++) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+export function usePushNotifications() {
+  const { user } = useAuth();
+  const [isSupported, setIsSupported] = useState(false);
+  const [isSubscribed, setIsSubscribed] = useState(false);
+  const [permission, setPermission] = useState<NotificationPermission>("default");
+  const [loading, setLoading] = useState(false);
+
+  // Check if push notifications are supported
+  useEffect(() => {
+    const supported =
+      "serviceWorker" in navigator &&
+      "PushManager" in window &&
+      "Notification" in window;
+    setIsSupported(supported);
+
+    if (supported) {
+      setPermission(Notification.permission);
+    }
+  }, []);
+
+  // Check current subscription status on mount
+  useEffect(() => {
+    if (!isSupported || !user) return;
+
+    const checkSubscription = async () => {
+      try {
+        const registration = await navigator.serviceWorker.ready;
+        const subscription = await registration.pushManager.getSubscription();
+        setIsSubscribed(!!subscription);
+      } catch {
+        setIsSubscribed(false);
+      }
+    };
+
+    checkSubscription();
+  }, [isSupported, user]);
+
+  const subscribe = useCallback(async (): Promise<{ error: string | null }> => {
+    if (!user || !isSupported) {
+      return { error: "Push notifications are not supported" };
+    }
+
+    setLoading(true);
+
+    try {
+      // Request notification permission
+      const perm = await Notification.requestPermission();
+      setPermission(perm);
+
+      if (perm !== "granted") {
+        setLoading(false);
+        return { error: "Notification permission denied" };
+      }
+
+      const config = getConfig();
+      const vapidKey = config.VITE_VAPID_PUBLIC_KEY;
+      if (!vapidKey) {
+        setLoading(false);
+        return { error: "VAPID key not configured" };
+      }
+
+      const registration = await navigator.serviceWorker.ready;
+
+      // Subscribe to push
+      const subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(vapidKey),
+      });
+
+      const subJson = subscription.toJSON();
+      const endpoint = subJson.endpoint!;
+      const p256dh = subJson.keys!.p256dh!;
+      const auth = subJson.keys!.auth!;
+
+      // Save subscription to Supabase
+      const sb = supabase as any;
+      const { error: dbError } = await sb
+        .from("push_subscriptions")
+        .upsert(
+          {
+            user_id: user.id,
+            endpoint,
+            p256dh,
+            auth,
+          },
+          { onConflict: "user_id,endpoint" }
+        );
+
+      if (dbError) {
+        setLoading(false);
+        return { error: dbError.message };
+      }
+
+      localStorage.setItem(PUSH_ENABLED_KEY, "true");
+      setIsSubscribed(true);
+      setLoading(false);
+      return { error: null };
+    } catch (err: any) {
+      setLoading(false);
+      return { error: err?.message || "Failed to subscribe" };
+    }
+  }, [user, isSupported]);
+
+  const unsubscribe = useCallback(async (): Promise<{ error: string | null }> => {
+    if (!user) return { error: "Not authenticated" };
+
+    setLoading(true);
+
+    try {
+      const registration = await navigator.serviceWorker.ready;
+      const subscription = await registration.pushManager.getSubscription();
+
+      if (subscription) {
+        const endpoint = subscription.endpoint;
+
+        // Unsubscribe from push
+        await subscription.unsubscribe();
+
+        // Remove from Supabase
+        const sb = supabase as any;
+        await sb
+          .from("push_subscriptions")
+          .delete()
+          .eq("user_id", user.id)
+          .eq("endpoint", endpoint);
+      }
+
+      localStorage.removeItem(PUSH_ENABLED_KEY);
+      setIsSubscribed(false);
+      setLoading(false);
+      return { error: null };
+    } catch (err: any) {
+      setLoading(false);
+      return { error: err?.message || "Failed to unsubscribe" };
+    }
+  }, [user]);
+
+  const toggle = useCallback(async (): Promise<{ error: string | null }> => {
+    if (isSubscribed) {
+      return unsubscribe();
+    }
+    return subscribe();
+  }, [isSubscribed, subscribe, unsubscribe]);
+
+  return {
+    isSupported,
+    isSubscribed,
+    permission,
+    loading,
+    subscribe,
+    unsubscribe,
+    toggle,
+  };
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,6 +4,7 @@ export interface Config {
   VITE_ADMIN_EMAILS: string;
   VITE_LANG_SERVICE: string;
   VITE_SENTRY_DSN: string;
+  VITE_VAPID_PUBLIC_KEY?: string;
   // These are only available in DEV. In PROD, they are proxied via Cloudflare Worker.
   VITE_GROQ_API_KEY?: string;
   VITE_ABLY_KEY?: string;
@@ -30,6 +31,7 @@ export async function loadConfig(): Promise<Config> {
       VITE_ADMIN_EMAILS: import.meta.env.VITE_ADMIN_EMAILS || "",
       VITE_LANG_SERVICE: import.meta.env.VITE_LANG_SERVICE || "",
       VITE_SENTRY_DSN: import.meta.env.VITE_SENTRY_DSN || "",
+      VITE_VAPID_PUBLIC_KEY: import.meta.env.VITE_VAPID_PUBLIC_KEY || "",
     };
   } else {
     try {
@@ -49,6 +51,7 @@ export async function loadConfig(): Promise<Config> {
         VITE_ADMIN_EMAILS: import.meta.env.VITE_ADMIN_EMAILS || "",
         VITE_LANG_SERVICE: import.meta.env.VITE_LANG_SERVICE || "",
         VITE_SENTRY_DSN: import.meta.env.VITE_SENTRY_DSN || "",
+        VITE_VAPID_PUBLIC_KEY: import.meta.env.VITE_VAPID_PUBLIC_KEY || "",
       };
     }
   }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/hooks/useAuth";
 import { useProfile } from "@/hooks/useProfile";
 import Navbar from "@/components/Navbar";
-import { LogOut, ArrowLeft, Shield, Settings, Check, AtSign, Globe, Palette, Moon, Sun, Monitor, Pipette, WandSparkles, Music, Volume2, VolumeX, Clock, Lock, Eye, EyeOff, KeyRound, Layout, Type, Square, Grid } from "lucide-react";
+import { LogOut, ArrowLeft, Shield, Settings, Check, AtSign, Globe, Palette, Moon, Sun, Monitor, Pipette, WandSparkles, Music, Volume2, VolumeX, Clock, Lock, Eye, EyeOff, KeyRound, Layout, Type, Square, Grid, Bell, BellOff } from "lucide-react";
 import { FrogLoader } from "@/components/ui/FrogLoader";
 import { motion, AnimatePresence } from "framer-motion";
 import { Helmet } from "react-helmet-async";
@@ -12,6 +12,7 @@ import { useTranslation } from "react-i18next";
 import { useTheme } from "@/components/theme-provider";
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp";
 import { hashPin, verifyPin, APP_LOCK_HASH_KEY, APP_LOCK_SESSION_KEY, APP_LOCK_Q1_KEY, APP_LOCK_Q2_KEY, APP_LOCK_A1_HASH_KEY, APP_LOCK_A2_HASH_KEY, PREDEFINED_QUESTIONS, formatAnswer } from "@/lib/pin";
+import { usePushNotifications } from "@/hooks/usePushNotifications";
 import {
     AlertDialog,
     AlertDialogAction,
@@ -30,6 +31,7 @@ const SettingsPage = () => {
     const navigate = useNavigate();
     const { t, i18n } = useTranslation();
     const { theme, color, customColor, font, radius, animateColor, cursorTrail, grid, soundEnabled, shadowWalk, setTheme, setColor, setCustomColor, setFont, setRadius, setAnimateColor, setCursorTrail, setGrid, setSoundEnabled, setShadowWalk } = useTheme();
+    const pushNotifications = usePushNotifications();
 
     const [newUsername, setNewUsername] = useState("");
     const [usernameError, setUsernameError] = useState<string | null>(null);
@@ -375,6 +377,45 @@ const SettingsPage = () => {
                                                 <p className="text-[11px] text-muted-foreground mt-2">
                                                     3–20 characters. Lowercase letters, numbers, and underscores only.
                                                 </p>
+                                            </div>
+
+                                            {/* Push Notifications */}
+                                            <div className="pt-6 border-t border-border">
+                                                <h2 className="text-lg font-bold mb-1 flex items-center gap-2">
+                                                    <Bell size={20} />
+                                                    Push Notifications
+                                                </h2>
+                                                <p className="text-sm text-muted-foreground mb-4">
+                                                    Get notified when someone likes, comments, follows, or mentions you — even when the app is closed.
+                                                </p>
+                                                {!pushNotifications.isSupported ? (
+                                                    <p className="text-sm text-muted-foreground italic">Push notifications are not supported in this browser.</p>
+                                                ) : pushNotifications.permission === "denied" ? (
+                                                    <p className="text-sm text-destructive">Notifications are blocked. Please enable them in your browser settings.</p>
+                                                ) : (
+                                                    <button
+                                                        onClick={async () => {
+                                                            const { error } = await pushNotifications.toggle();
+                                                            if (error) {
+                                                                toast.error(error);
+                                                            } else {
+                                                                toast.success(pushNotifications.isSubscribed ? "Push notifications disabled" : "Push notifications enabled!");
+                                                            }
+                                                        }}
+                                                        disabled={pushNotifications.loading}
+                                                        className={`gum-btn flex items-center justify-center gap-2 px-6 py-2.5 text-sm font-bold w-full sm:w-auto ${
+                                                            pushNotifications.isSubscribed
+                                                                ? "border-2 border-foreground bg-secondary hover:bg-secondary/80"
+                                                                : "bg-primary text-primary-foreground"
+                                                        }`}
+                                                    >
+                                                        {pushNotifications.isSubscribed ? (
+                                                            <><BellOff size={18} /> Disable Notifications</>
+                                                        ) : (
+                                                            <><Bell size={18} /> Enable Notifications</>
+                                                        )}
+                                                    </button>
+                                                )}
                                             </div>
 
                                             {/* Log Out Section */}

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,0 +1,61 @@
+import { precacheAndRoute } from 'workbox-precaching';
+
+// Workbox precache manifest (injected by vite-plugin-pwa)
+precacheAndRoute(self.__WB_MANIFEST);
+
+// Claim clients immediately so the SW activates on first install
+(self as any).skipWaiting();
+(self as any).clients.claim();
+
+// =============================================================================
+// Push Notification Handler
+// =============================================================================
+
+self.addEventListener('push', (event: any) => {
+  let data = {
+    title: 'genjutsu',
+    body: 'You got a new notification — open app to see',
+    icon: '/icon-192x192.png',
+    url: 'https://genjutsu-social.vercel.app',
+  };
+
+  try {
+    if (event.data) {
+      const parsed = event.data.json();
+      data = { ...data, ...parsed };
+    }
+  } catch {
+    // Use defaults if payload parsing fails
+  }
+
+  event.waitUntil(
+    (self as any).registration.showNotification(data.title, {
+      body: data.body,
+      icon: data.icon,
+      badge: '/icon-192x192.png',
+      tag: 'genjutsu-notification',
+      renotify: true,
+      data: { url: data.url },
+    })
+  );
+});
+
+// Handle notification click — open/focus the app
+self.addEventListener('notificationclick', (event: any) => {
+  event.notification.close();
+
+  const targetUrl = event.notification.data?.url || 'https://genjutsu-social.vercel.app';
+
+  event.waitUntil(
+    (self as any).clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList: any[]) => {
+      // If the app is already open, focus it
+      for (const client of clientList) {
+        if (client.url.includes('genjutsu-social.vercel.app') && 'focus' in client) {
+          return client.focus();
+        }
+      }
+      // Otherwise open a new window
+      return (self as any).clients.openWindow(targetUrl);
+    })
+  );
+});

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -1,0 +1,361 @@
+// Supabase Edge Function: send-push
+// Called by the DB trigger on notifications INSERT via pg_net
+// Sends web push notifications using VAPID + RFC 8291 encryption
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+// =============================================================================
+// Web Push Helpers (VAPID + Encryption via Web Crypto API)
+// =============================================================================
+
+function base64UrlEncode(buffer: ArrayBuffer | Uint8Array): string {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64UrlDecode(str: string): Uint8Array {
+  str = str.replace(/-/g, "+").replace(/_/g, "/");
+  while (str.length % 4) str += "=";
+  const binary = atob(str);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+async function importVapidKeys(publicKeyB64: string, privateKeyB64: string) {
+  const publicKeyBytes = base64UrlDecode(publicKeyB64);
+  const privateKeyBytes = base64UrlDecode(privateKeyB64);
+
+  const jwk = {
+    kty: "EC",
+    crv: "P-256",
+    x: base64UrlEncode(publicKeyBytes.slice(1, 33)),
+    y: base64UrlEncode(publicKeyBytes.slice(33, 65)),
+    d: base64UrlEncode(privateKeyBytes),
+  };
+
+  const privateKey = await crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"]
+  );
+
+  return { privateKey, publicKeyBytes };
+}
+
+async function createVapidAuthHeader(
+  endpoint: string,
+  vapidPublicKey: string,
+  vapidPrivateKey: string,
+  subject: string
+) {
+  const endpointUrl = new URL(endpoint);
+  const audience = `${endpointUrl.protocol}//${endpointUrl.host}`;
+
+  const { privateKey, publicKeyBytes } = await importVapidKeys(vapidPublicKey, vapidPrivateKey);
+
+  const header = { typ: "JWT", alg: "ES256" };
+  const payload = {
+    aud: audience,
+    exp: Math.floor(Date.now() / 1000) + 12 * 60 * 60,
+    sub: subject,
+  };
+
+  const encodedHeader = base64UrlEncode(new TextEncoder().encode(JSON.stringify(header)));
+  const encodedPayload = base64UrlEncode(new TextEncoder().encode(JSON.stringify(payload)));
+  const unsignedToken = `${encodedHeader}.${encodedPayload}`;
+
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    privateKey,
+    new TextEncoder().encode(unsignedToken)
+  );
+
+  const sigBytes = new Uint8Array(signature);
+  const rawSig =
+    sigBytes.length === 64
+      ? sigBytes
+      : (() => {
+          let offset = 3;
+          const rLen = sigBytes[offset++];
+          const rRaw = sigBytes.slice(offset, offset + rLen);
+          offset += rLen + 1;
+          const sLen = sigBytes[offset++];
+          const sRaw = sigBytes.slice(offset, offset + sLen);
+          const r = new Uint8Array(32);
+          const s = new Uint8Array(32);
+          r.set(rRaw.length > 32 ? rRaw.slice(rRaw.length - 32) : rRaw, 32 - Math.min(rRaw.length, 32));
+          s.set(sRaw.length > 32 ? sRaw.slice(sRaw.length - 32) : sRaw, 32 - Math.min(sRaw.length, 32));
+          const out = new Uint8Array(64);
+          out.set(r, 0);
+          out.set(s, 32);
+          return out;
+        })();
+
+  const token = `${unsignedToken}.${base64UrlEncode(rawSig)}`;
+
+  return {
+    authorization: `vapid t=${token}, k=${base64UrlEncode(publicKeyBytes)}`,
+  };
+}
+
+async function encryptPayload(
+  subscriptionKeys: { p256dh: string; auth: string },
+  payloadText: string
+): Promise<Uint8Array> {
+  const p256dhBytes = base64UrlDecode(subscriptionKeys.p256dh);
+  const authBytes = base64UrlDecode(subscriptionKeys.auth);
+  const payloadBytes = new TextEncoder().encode(payloadText);
+
+  const subscriberKey = await crypto.subtle.importKey(
+    "raw",
+    p256dhBytes,
+    { name: "ECDH", namedCurve: "P-256" },
+    false,
+    []
+  );
+
+  const localKeyPair = await crypto.subtle.generateKey(
+    { name: "ECDH", namedCurve: "P-256" },
+    true,
+    ["deriveBits"]
+  );
+
+  const sharedSecret = new Uint8Array(
+    await crypto.subtle.deriveBits(
+      { name: "ECDH", public: subscriberKey },
+      localKeyPair.privateKey,
+      256
+    )
+  );
+
+  const localPublicKeyBytes = new Uint8Array(
+    await crypto.subtle.exportKey("raw", localKeyPair.publicKey)
+  );
+
+  const prkHmacKey = await crypto.subtle.importKey(
+    "raw",
+    authBytes,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const prk = new Uint8Array(await crypto.subtle.sign("HMAC", prkHmacKey, sharedSecret));
+
+  const keyInfoBuf = new Uint8Array([
+    ...new TextEncoder().encode("WebPush: info\0"),
+    ...p256dhBytes,
+    ...localPublicKeyBytes,
+  ]);
+
+  const ikmHmacKey = await crypto.subtle.importKey(
+    "raw",
+    prk,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const ikm = new Uint8Array(
+    await crypto.subtle.sign("HMAC", ikmHmacKey, new Uint8Array([...keyInfoBuf, 1]))
+  ).slice(0, 32);
+
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+
+  const hkdfKey = await crypto.subtle.importKey("raw", ikm, { name: "HKDF" }, false, [
+    "deriveBits",
+  ]);
+
+  const cekInfo = new TextEncoder().encode("Content-Encoding: aes128gcm\0");
+  const nonceInfo = new TextEncoder().encode("Content-Encoding: nonce\0");
+
+  const cekBits = await crypto.subtle.deriveBits(
+    { name: "HKDF", hash: "SHA-256", salt, info: cekInfo },
+    hkdfKey,
+    128
+  );
+
+  const nonceBits = await crypto.subtle.deriveBits(
+    { name: "HKDF", hash: "SHA-256", salt, info: nonceInfo },
+    hkdfKey,
+    96
+  );
+
+  const record = new Uint8Array(payloadBytes.length + 1);
+  record.set(payloadBytes, 0);
+  record[payloadBytes.length] = 2;
+
+  const cek = await crypto.subtle.importKey("raw", cekBits, { name: "AES-GCM" }, false, [
+    "encrypt",
+  ]);
+
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: new Uint8Array(nonceBits), tagLength: 128 },
+    cek,
+    record
+  );
+
+  const rs = 4096;
+  const headerBuf = new Uint8Array(86);
+  headerBuf.set(salt, 0);
+  new DataView(headerBuf.buffer).setUint32(16, rs);
+  headerBuf[20] = 65;
+  headerBuf.set(localPublicKeyBytes, 21);
+
+  const body = new Uint8Array(headerBuf.length + ciphertext.byteLength);
+  body.set(headerBuf, 0);
+  body.set(new Uint8Array(ciphertext), headerBuf.length);
+
+  return body;
+}
+
+async function sendWebPush(
+  subscription: { endpoint: string; p256dh: string; auth: string },
+  payload: Record<string, string>,
+  vapidPublicKey: string,
+  vapidPrivateKey: string,
+  vapidSubject: string
+) {
+  const { authorization } = await createVapidAuthHeader(
+    subscription.endpoint,
+    vapidPublicKey,
+    vapidPrivateKey,
+    vapidSubject
+  );
+
+  const encryptedBody = await encryptPayload(
+    { p256dh: subscription.p256dh, auth: subscription.auth },
+    JSON.stringify(payload)
+  );
+
+  return fetch(subscription.endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: authorization,
+      "Content-Encoding": "aes128gcm",
+      "Content-Type": "application/octet-stream",
+      TTL: "86400",
+      Urgency: "normal",
+    },
+    body: encryptedBody,
+  });
+}
+
+// =============================================================================
+// Edge Function Handler
+// =============================================================================
+
+Deno.serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+
+  try {
+    // Verify the request comes from Supabase (service role)
+    const authHeader = req.headers.get("Authorization") || "";
+    const token = authHeader.replace("Bearer ", "");
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+    if (!token || token !== serviceKey) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const body = await req.json();
+    const userId = body.user_id;
+    if (!userId) {
+      return new Response(JSON.stringify({ error: "missing user_id" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Get VAPID keys from env
+    const vapidPublicKey = Deno.env.get("VAPID_PUBLIC_KEY");
+    const vapidPrivateKey = Deno.env.get("VAPID_PRIVATE_KEY");
+    if (!vapidPublicKey || !vapidPrivateKey) {
+      return new Response(JSON.stringify({ error: "VAPID keys not configured" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Fetch push subscriptions using service role
+    const supabase = createClient(supabaseUrl, serviceKey);
+    const { data: subscriptions, error: fetchError } = await supabase
+      .from("push_subscriptions")
+      .select("endpoint, p256dh, auth")
+      .eq("user_id", userId);
+
+    if (fetchError) {
+      return new Response(JSON.stringify({ error: fetchError.message }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (!subscriptions || subscriptions.length === 0) {
+      return new Response(JSON.stringify({ sent: 0 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const pushPayload = {
+      title: "genjutsu",
+      body: "You got a new notification \u2014 open app to see",
+      icon: "/icon-192x192.png",
+      url: "https://genjutsu-social.vercel.app",
+    };
+
+    const vapidSubject = "mailto:genjutsu@proton.me";
+    let sent = 0;
+    let failed = 0;
+    const staleEndpoints: string[] = [];
+
+    for (const sub of subscriptions) {
+      try {
+        const pushResponse = await sendWebPush(
+          sub,
+          pushPayload,
+          vapidPublicKey,
+          vapidPrivateKey,
+          vapidSubject
+        );
+        if (pushResponse.status === 201 || pushResponse.status === 200) {
+          sent++;
+        } else if (pushResponse.status === 404 || pushResponse.status === 410) {
+          staleEndpoints.push(sub.endpoint);
+          failed++;
+        } else {
+          failed++;
+        }
+      } catch {
+        failed++;
+      }
+    }
+
+    // Clean up stale/expired subscriptions
+    if (staleEndpoints.length > 0) {
+      await supabase
+        .from("push_subscriptions")
+        .delete()
+        .eq("user_id", userId)
+        .in("endpoint", staleEndpoints);
+    }
+
+    return new Response(JSON.stringify({ sent, failed }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (e) {
+    return new Response(JSON.stringify({ error: (e as Error).message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+});

--- a/supabase/init.sql
+++ b/supabase/init.sql
@@ -1102,6 +1102,73 @@ CREATE TRIGGER on_comment_mention_notify
 
 
 -- =============================================================================
+-- PUSH NOTIFICATIONS
+-- =============================================================================
+
+-- Push subscription storage for Web Push API
+CREATE TABLE public.push_subscriptions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  endpoint TEXT NOT NULL,
+  p256dh TEXT NOT NULL,
+  auth TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(user_id, endpoint)
+);
+
+CREATE INDEX idx_push_subscriptions_user ON public.push_subscriptions (user_id);
+
+ALTER TABLE public.push_subscriptions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own push subscriptions"
+  ON public.push_subscriptions FOR SELECT USING ((select auth.uid()) = user_id);
+CREATE POLICY "Users can insert own push subscriptions"
+  ON public.push_subscriptions FOR INSERT WITH CHECK ((select auth.uid()) = user_id);
+CREATE POLICY "Users can delete own push subscriptions"
+  ON public.push_subscriptions FOR DELETE USING ((select auth.uid()) = user_id);
+
+-- Trigger: Send push notification via Supabase Edge Function
+CREATE OR REPLACE FUNCTION public.send_push_notification()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_project_url TEXT;
+  v_service_key TEXT;
+BEGIN
+  -- Get the Supabase URL and service role key from vault
+  v_project_url := current_setting('app.settings.supabase_url', true);
+  IF v_project_url IS NULL OR v_project_url = '' THEN
+    v_project_url := 'https://scvikrxfxijqoedfryvx.supabase.co';
+  END IF;
+
+  SELECT decrypted_secret INTO v_service_key
+  FROM vault.decrypted_secrets
+  WHERE name = 'supabase_service_role_key'
+  LIMIT 1;
+
+  IF v_service_key IS NOT NULL THEN
+    -- Check if user has any push subscriptions before making HTTP call
+    IF EXISTS (SELECT 1 FROM public.push_subscriptions WHERE user_id = NEW.user_id) THEN
+      PERFORM net.http_post(
+        url := v_project_url || '/functions/v1/send-push',
+        headers := jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || v_service_key
+        ),
+        body := jsonb_build_object('user_id', NEW.user_id)
+      );
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, net, vault;
+
+CREATE TRIGGER on_notification_send_push
+  AFTER INSERT ON public.notifications
+  FOR EACH ROW EXECUTE FUNCTION public.send_push_notification();
+
+
+-- =============================================================================
 -- ACCOUNT MANAGEMENT
 -- =============================================================================
 

--- a/supabase/migrations/20260413_push_notifications.sql
+++ b/supabase/migrations/20260413_push_notifications.sql
@@ -1,0 +1,67 @@
+-- =============================================================================
+-- Push Notifications — Web Push API support
+-- =============================================================================
+-- Requires: pg_net extension (enable in Supabase Dashboard → Database → Extensions)
+
+-- Push subscription storage
+CREATE TABLE IF NOT EXISTS public.push_subscriptions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  endpoint TEXT NOT NULL,
+  p256dh TEXT NOT NULL,
+  auth TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(user_id, endpoint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_subscriptions_user ON public.push_subscriptions (user_id);
+
+ALTER TABLE public.push_subscriptions ENABLE ROW LEVEL SECURITY;
+
+-- RLS: users can only manage their own subscriptions
+CREATE POLICY "Users can view own push subscriptions"
+  ON public.push_subscriptions FOR SELECT USING ((select auth.uid()) = user_id);
+CREATE POLICY "Users can insert own push subscriptions"
+  ON public.push_subscriptions FOR INSERT WITH CHECK ((select auth.uid()) = user_id);
+CREATE POLICY "Users can delete own push subscriptions"
+  ON public.push_subscriptions FOR DELETE USING ((select auth.uid()) = user_id);
+
+-- Trigger function: call Supabase Edge Function send-push via pg_net
+-- Uses supabase_service_role_key from Vault to authenticate
+CREATE OR REPLACE FUNCTION public.send_push_notification()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_project_url TEXT;
+  v_service_key TEXT;
+BEGIN
+  v_project_url := current_setting('app.settings.supabase_url', true);
+  IF v_project_url IS NULL OR v_project_url = '' THEN
+    v_project_url := 'https://scvikrxfxijqoedfryvx.supabase.co';
+  END IF;
+
+  SELECT decrypted_secret INTO v_service_key
+  FROM vault.decrypted_secrets
+  WHERE name = 'supabase_service_role_key'
+  LIMIT 1;
+
+  IF v_service_key IS NOT NULL THEN
+    IF EXISTS (SELECT 1 FROM public.push_subscriptions WHERE user_id = NEW.user_id) THEN
+      PERFORM net.http_post(
+        url := v_project_url || '/functions/v1/send-push',
+        headers := jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || v_service_key
+        ),
+        body := jsonb_build_object('user_id', NEW.user_id)
+      );
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, net, vault;
+
+-- Fire on every new notification
+CREATE TRIGGER on_notification_send_push
+  AFTER INSERT ON public.notifications
+  FOR EACH ROW EXECUTE FUNCTION public.send_push_notification();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,14 +28,14 @@ export default defineConfig(({ mode }) => ({
   plugins: [
     react(),
     VitePWA({
+      strategies: "injectManifest",
+      srcDir: "src",
+      filename: "sw.ts",
       registerType: "autoUpdate",
       injectRegister: "auto",
-      workbox: {
-        // PWABuilder requires a Service Worker, but we don't want to cache 
-        // the app offline so users always get the freshest network version.
-        clientsClaim: true,
-        skipWaiting: true,
-        runtimeCaching: [], // Empty caching array = no aggressive precaching
+      injectManifest: {
+        // No precaching — users always get the freshest network version
+        globPatterns: [],
       },
       manifest: {
         name: "genjutsu — everything vanishes",


### PR DESCRIPTION
## Summary
Adds web push notifications to genjutsu using a **Supabase Edge Function** for push delivery.

## Changes
- **Supabase Edge Function** (`supabase/functions/send-push/index.ts`): Handles VAPID signing + RFC 8291 encryption to send web push notifications
- **DB trigger** on `notifications` INSERT calls the Edge Function via `pg_net`
- **Service worker** (`src/sw.ts`): Push event + notification click handlers
- **Hook** (`src/hooks/usePushNotifications.ts`): Subscribe/unsubscribe logic
- **Settings UI**: Push notification toggle in Settings > General
- **Migration** (`supabase/migrations/20260413_push_notifications.sql`): `push_subscriptions` table + RLS + trigger
- **Cloudflare Worker**: Only change is adding `VITE_VAPID_PUBLIC_KEY` to `/config` response
- **init.sql**: Updated with push_subscriptions table and Edge Function trigger

## Setup Required
After merging:
1. Enable `pg_net` extension in Supabase Dashboard
2. Run the migration file in SQL Editor
3. Deploy the Edge Function with VAPID keys as env vars
4. Add `VAPID_PUBLIC_KEY` to Cloudflare Worker env vars
5. Add `VITE_VAPID_PUBLIC_KEY` to Vercel env vars