### PR TITLE
fix: prevent duplicate push notifications across accounts on same browser

### DIFF
--- a/src/hooks/usePushNotifications.ts
+++ b/src/hooks/usePushNotifications.ts
@@ -90,19 +90,14 @@ export function usePushNotifications() {
       const p256dh = subJson.keys!.p256dh!;
       const auth = subJson.keys!.auth!;
 
-      // Save subscription to Supabase
+      // Save subscription to Supabase via RPC
+      // This also removes the endpoint from any other user (same browser, different account)
       const sb = supabase as any;
-      const { error: dbError } = await sb
-        .from("push_subscriptions")
-        .upsert(
-          {
-            user_id: user.id,
-            endpoint,
-            p256dh,
-            auth,
-          },
-          { onConflict: "user_id,endpoint" }
-        );
+      const { error: dbError } = await sb.rpc("upsert_push_subscription", {
+        p_endpoint: endpoint,
+        p_p256dh: p256dh,
+        p_auth: auth,
+      });
 
       if (dbError) {
         setLoading(false);

--- a/supabase/init.sql
+++ b/supabase/init.sql
@@ -1127,6 +1127,32 @@ CREATE POLICY "Users can insert own push subscriptions"
 CREATE POLICY "Users can delete own push subscriptions"
   ON public.push_subscriptions FOR DELETE USING ((select auth.uid()) = user_id);
 
+-- RPC: Upsert push subscription (removes endpoint from other users first)
+CREATE OR REPLACE FUNCTION public.upsert_push_subscription(
+  p_endpoint TEXT,
+  p_p256dh TEXT,
+  p_auth TEXT
+)
+RETURNS VOID AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- Remove this endpoint from any other user (same browser, different account)
+  DELETE FROM public.push_subscriptions
+  WHERE endpoint = p_endpoint AND user_id <> v_user_id;
+
+  -- Upsert for the current user
+  INSERT INTO public.push_subscriptions (user_id, endpoint, p256dh, auth)
+  VALUES (v_user_id, p_endpoint, p_p256dh, p_auth)
+  ON CONFLICT (user_id, endpoint)
+  DO UPDATE SET p256dh = EXCLUDED.p256dh, auth = EXCLUDED.auth;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
 -- Trigger: Send push notification via Supabase Edge Function
 CREATE OR REPLACE FUNCTION public.send_push_notification()
 RETURNS TRIGGER AS $$

--- a/supabase/migrations/20260413_push_notifications.sql
+++ b/supabase/migrations/20260413_push_notifications.sql
@@ -26,6 +26,32 @@ CREATE POLICY "Users can insert own push subscriptions"
 CREATE POLICY "Users can delete own push subscriptions"
   ON public.push_subscriptions FOR DELETE USING ((select auth.uid()) = user_id);
 
+-- RPC: Upsert push subscription (removes endpoint from other users first)
+CREATE OR REPLACE FUNCTION public.upsert_push_subscription(
+  p_endpoint TEXT,
+  p_p256dh TEXT,
+  p_auth TEXT
+)
+RETURNS VOID AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- Remove this endpoint from any other user (same browser, different account)
+  DELETE FROM public.push_subscriptions
+  WHERE endpoint = p_endpoint AND user_id <> v_user_id;
+
+  -- Upsert for the current user
+  INSERT INTO public.push_subscriptions (user_id, endpoint, p256dh, auth)
+  VALUES (v_user_id, p_endpoint, p_p256dh, p_auth)
+  ON CONFLICT (user_id, endpoint)
+  DO UPDATE SET p256dh = EXCLUDED.p256dh, auth = EXCLUDED.auth;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
 -- Trigger function: call Supabase Edge Function send-push via pg_net
 -- Uses supabase_service_role_key from Vault to authenticate
 CREATE OR REPLACE FUNCTION public.send_push_notification()


### PR DESCRIPTION
When two accounts enable push notifications on the same browser, they share the same push endpoint. This caused both accounts to receive push notifications.

Adds upsert_push_subscription RPC function (SECURITY DEFINER) that removes the endpoint from other users before upserting, ensuring one browser = one account for push.