### PR TITLE
fix: use absolute URL for push notification icon

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -15,7 +15,7 @@ self.addEventListener('push', (event: any) => {
   let data = {
     title: 'genjutsu',
     body: 'You got a new notification — open app to see',
-    icon: '/icon-192x192.png',
+    icon: 'https://genjutsu-social.vercel.app/icon-192x192.png',
     url: 'https://genjutsu-social.vercel.app',
   };
 
@@ -32,7 +32,7 @@ self.addEventListener('push', (event: any) => {
     (self as any).registration.showNotification(data.title, {
       body: data.body,
       icon: data.icon,
-      badge: '/icon-192x192.png',
+      badge: 'https://genjutsu-social.vercel.app/icon-192x192.png',
       tag: 'genjutsu-notification',
       renotify: true,
       data: { url: data.url },

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -302,7 +302,7 @@ Deno.serve(async (req) => {
     const pushPayload = {
       title: "genjutsu",
       body: "You got a new notification \u2014 open app to see",
-      icon: "/icon-192x192.png",
+      icon: "https://genjutsu-social.vercel.app/icon-192x192.png",
       url: "https://genjutsu-social.vercel.app",
     };
 


### PR DESCRIPTION
The push notification icon was not showing on Android because the path was relative (`/icon-192x192.png`). Changed to absolute URL (`https://genjutsu-social.vercel.app/icon-192x192.png`) in both the Edge Function payload and service worker.

After merging, redeploy the Edge Function:
```bash
npx supabase functions deploy send-push --project-ref scvikrxfxijqoedfryvx --no-verify-jwt
```