### PR TITLE
fix: remove deprecated baseUrl from tsconfig files

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,7 +22,6 @@
     "noImplicitAny": false,
     "noFallthroughCasesInSwitch": false,
 
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "files": [],
   "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }],
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
Removes deprecated `baseUrl` from `tsconfig.app.json` and `tsconfig.json`.

`baseUrl` is deprecated in TypeScript 6.x and will stop working in TypeScript 7.0. The `@/*` path alias works without it since `paths` already uses relative `./src/*` notation, and Vite handles actual module resolution via `resolve.alias` in `vite.config.ts`.

Build and lint both pass with this change.