### PR TITLE
feat: show detailed push notification messages

### DIFF
--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -261,6 +261,9 @@ Deno.serve(async (req) => {
 
     const body = await req.json();
     const userId = body.user_id;
+    const notificationType = body.type;
+    const actorId = body.actor_id;
+    const postId = body.post_id;
     if (!userId) {
       return new Response(JSON.stringify({ error: "missing user_id" }), {
         status: 400,
@@ -299,11 +302,60 @@ Deno.serve(async (req) => {
       });
     }
 
+    // Build detailed notification message
+    let notifBody = "You got a new notification — open app to see";
+    let notifUrl = "https://genjutsu-social.vercel.app";
+
+    if (actorId && notificationType) {
+      // Look up actor's display name
+      const { data: actorProfile } = await supabase
+        .from("profiles")
+        .select("display_name, username")
+        .eq("user_id", actorId)
+        .single();
+
+      const actorName = actorProfile?.display_name || "Someone";
+      const actorUsername = actorProfile?.username;
+
+      switch (notificationType) {
+        case "like":
+          notifBody = `${actorName} resonated with your post`;
+          break;
+        case "unlike":
+          notifBody = `${actorName} stopped resonating with your post`;
+          break;
+        case "comment":
+          notifBody = `${actorName} echoed on your post`;
+          break;
+        case "uncomment":
+          notifBody = `${actorName} erased their echo on your post`;
+          break;
+        case "follow":
+          notifBody = `${actorName} started following you`;
+          break;
+        case "unfollow":
+          notifBody = `${actorName} stopped following you`;
+          break;
+        case "mention":
+          notifBody = `${actorName} mentioned you in a void`;
+          break;
+      }
+
+      // Set click URL based on notification type
+      if (notificationType === "follow" || notificationType === "unfollow") {
+        if (actorUsername) {
+          notifUrl = `https://genjutsu-social.vercel.app/u/${actorUsername}`;
+        }
+      } else if (postId) {
+        notifUrl = `https://genjutsu-social.vercel.app/post/${postId}`;
+      }
+    }
+
     const pushPayload = {
       title: "genjutsu",
-      body: "You got a new notification \u2014 open app to see",
+      body: notifBody,
       icon: "https://genjutsu-social.vercel.app/icon-192x192.png",
-      url: "https://genjutsu-social.vercel.app",
+      url: notifUrl,
     };
 
     const vapidSubject = "mailto:genjutsu@proton.me";

--- a/supabase/init.sql
+++ b/supabase/init.sql
@@ -1180,7 +1180,12 @@ BEGIN
           'Content-Type', 'application/json',
           'Authorization', 'Bearer ' || v_service_key
         ),
-        body := jsonb_build_object('user_id', NEW.user_id)
+        body := jsonb_build_object(
+          'user_id', NEW.user_id,
+          'type', NEW.type,
+          'actor_id', NEW.actor_id,
+          'post_id', NEW.post_id
+        )
       );
     END IF;
   END IF;

--- a/supabase/migrations/20260413_push_notifications.sql
+++ b/supabase/migrations/20260413_push_notifications.sql
@@ -78,7 +78,12 @@ BEGIN
           'Content-Type', 'application/json',
           'Authorization', 'Bearer ' || v_service_key
         ),
-        body := jsonb_build_object('user_id', NEW.user_id)
+        body := jsonb_build_object(
+          'user_id', NEW.user_id,
+          'type', NEW.type,
+          'actor_id', NEW.actor_id,
+          'post_id', NEW.post_id
+        )
       );
     END IF;
   END IF;


### PR DESCRIPTION
Push notifications now show the actual message instead of generic "You got a new notification".

## What changed

### DB trigger (`send_push_notification`)
- Now passes `type`, `actor_id`, and `post_id` to the Edge Function (previously only sent `user_id`)

### Edge Function (`send-push/index.ts`)
- Looks up actor display name from `profiles` table
- Builds notification message matching in-app notifications:
  - like → "username resonated with your post"
  - unlike → "username stopped resonating with your post"
  - comment → "username echoed on your post"
  - uncomment → "username erased their echo on your post"
  - follow → "username started following you"
  - unfollow → "username stopped following you"
  - mention → "username mentioned you in a void"
- Click URL now opens the relevant post or profile
- Falls back to generic message if data is missing

## After merging
1. Run the updated trigger SQL in Supabase SQL Editor
2. Pull latest and redeploy Edge Function