### PR TITLE
feat: show detailed push notification messages + stacking fix

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -33,7 +33,7 @@ self.addEventListener('push', (event: any) => {
       body: data.body,
       icon: data.icon,
       badge: 'https://genjutsu-social.vercel.app/badge-96x96.png',
-      tag: 'genjutsu-notification',
+      tag: `genjutsu-${Date.now()}`,
       renotify: true,
       data: { url: data.url },
     })


### PR DESCRIPTION
Push notifications now show actual messages instead of generic "You got a new notification".

## Changes

### Detailed messages (Edge Function)
- Looks up actor display name from profiles table
- Builds message matching in-app notifications:
  - like → "username resonated with your post"
  - comment → "username echoed on your post"
  - follow → "username started following you"
  - mention → "username mentioned you in a void"
  - etc.
- Click URL opens relevant post or profile
- Falls back to generic message if data missing

### DB trigger
- Now passes `type`, `actor_id`, `post_id` to Edge Function (not just `user_id`)

### Notification stacking (Service Worker)
- Each notification gets a unique tag so multiple notifications stack instead of replacing each other

## After merging
1. Run the updated trigger SQL in Supabase SQL Editor
2. Pull latest and redeploy Edge Function:
   ```bash
   git pull origin main
   npx supabase functions deploy send-push --project-ref scvikrxfxijqoedfryvx --no-verify-jwt
   ```
3. Close and reopen the app to load the new service worker