### PR TITLE
fix: allow multiple push notifications to stack

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -33,7 +33,7 @@ self.addEventListener('push', (event: any) => {
       body: data.body,
       icon: data.icon,
       badge: 'https://genjutsu-social.vercel.app/badge-96x96.png',
-      tag: 'genjutsu-notification',
+      tag: `genjutsu-${Date.now()}`,
       renotify: true,
       data: { url: data.url },
     })


### PR DESCRIPTION
## Problem
Multiple push notifications replace each other instead of stacking. When a second notification arrives, the first one disappears.

## Root Cause
The service worker used a hardcoded tag `genjutsu-notification` for all notifications. The Web Push API replaces notifications with the same tag.

## Fix
Each notification now gets a unique tag using `Date.now()`, so they all stack separately.

## Changes
- `src/sw.ts`: Changed `tag: 'genjutsu-notification'` to `tag: \`genjutsu-${Date.now()}\``

## After merging
No SQL or Edge Function redeploy needed. Just close and reopen the app to load the new service worker.