### PR TITLE
Harden notification triggers to avoid FK violations during account-deletion cascades

### DIFF
--- a/supabase/init.sql
+++ b/supabase/init.sql
@@ -1352,14 +1352,25 @@ BEGIN
   FROM public.posts
   WHERE id = OLD.post_id;
 
-  IF v_post_owner IS NOT NULL AND v_post_owner <> OLD.user_id THEN
-    INSERT INTO public.notifications (user_id, actor_id, type, post_id)
-    VALUES (v_post_owner, OLD.user_id, 'unlike', OLD.post_id);
+  IF v_post_owner IS NULL OR v_post_owner = OLD.user_id THEN
+    RETURN OLD;
   END IF;
+
+  -- Guard against account-deletion cascades where either side may be deleted.
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = OLD.user_id) THEN
+    RETURN OLD;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = v_post_owner) THEN
+    RETURN OLD;
+  END IF;
+
+  INSERT INTO public.notifications (user_id, actor_id, type, post_id)
+  VALUES (v_post_owner, OLD.user_id, 'unlike', OLD.post_id);
 
   RETURN OLD;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, auth;
 
 CREATE TRIGGER on_unlike_notify
   AFTER DELETE ON public.likes
@@ -1399,14 +1410,25 @@ BEGIN
   FROM public.posts
   WHERE id = OLD.post_id;
 
-  IF v_post_owner IS NOT NULL AND v_post_owner <> OLD.user_id THEN
-    INSERT INTO public.notifications (user_id, actor_id, type, post_id)
-    VALUES (v_post_owner, OLD.user_id, 'uncomment', OLD.post_id);
+  IF v_post_owner IS NULL OR v_post_owner = OLD.user_id THEN
+    RETURN OLD;
   END IF;
+
+  -- Guard against account-deletion cascades where either side may be deleted.
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = OLD.user_id) THEN
+    RETURN OLD;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = v_post_owner) THEN
+    RETURN OLD;
+  END IF;
+
+  INSERT INTO public.notifications (user_id, actor_id, type, post_id)
+  VALUES (v_post_owner, OLD.user_id, 'uncomment', OLD.post_id);
 
   RETURN OLD;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, auth;
 
 CREATE TRIGGER on_uncomment_notify
   AFTER DELETE ON public.comments
@@ -1437,14 +1459,25 @@ BEGIN
     RETURN OLD;
   END IF;
 
-  IF OLD.follower_id <> OLD.following_id THEN
-    INSERT INTO public.notifications (user_id, actor_id, type)
-    VALUES (OLD.following_id, OLD.follower_id, 'unfollow');
+  IF OLD.follower_id = OLD.following_id THEN
+    RETURN OLD;
   END IF;
+
+  -- Guard against account-deletion cascades where either side may be deleted.
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = OLD.follower_id) THEN
+    RETURN OLD;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = OLD.following_id) THEN
+    RETURN OLD;
+  END IF;
+
+  INSERT INTO public.notifications (user_id, actor_id, type)
+  VALUES (OLD.following_id, OLD.follower_id, 'unfollow');
 
   RETURN OLD;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, auth;
 
 CREATE TRIGGER on_unfollow_notify
   AFTER DELETE ON public.follows

--- a/supabase/migrations/20260426190000_fix_delete_account_notification_fk.sql
+++ b/supabase/migrations/20260426190000_fix_delete_account_notification_fk.sql
@@ -1,0 +1,107 @@
+-- Prevent FK violations in notifications during account-deletion cascades.
+--
+-- When a user account is deleted, cascading deletes can remove likes/comments/follows
+-- rows and fire AFTER DELETE notification triggers. Those triggers may attempt to
+-- insert notifications with actor_id/follower_id that no longer exists in auth.users,
+-- causing notifications_actor_id_fkey violations.
+--
+-- This migration hardens negative-notification trigger functions by validating
+-- actor and recipient existence in auth.users before inserting notifications.
+
+CREATE OR REPLACE FUNCTION public.notify_on_unlike()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_post_owner UUID;
+BEGIN
+  -- Only create a notification when the authenticated user is the liker
+  IF auth.uid() IS NULL OR auth.uid() <> OLD.user_id THEN
+    RETURN OLD;
+  END IF;
+
+  SELECT user_id INTO v_post_owner
+  FROM public.posts
+  WHERE id = OLD.post_id;
+
+  IF v_post_owner IS NULL OR v_post_owner = OLD.user_id THEN
+    RETURN OLD;
+  END IF;
+
+  -- Guard against account-deletion cascades where either side may be deleted.
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = OLD.user_id) THEN
+    RETURN OLD;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = v_post_owner) THEN
+    RETURN OLD;
+  END IF;
+
+  INSERT INTO public.notifications (user_id, actor_id, type, post_id)
+  VALUES (v_post_owner, OLD.user_id, 'unlike', OLD.post_id);
+
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, auth;
+
+
+CREATE OR REPLACE FUNCTION public.notify_on_uncomment()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_post_owner UUID;
+BEGIN
+  -- Only create a notification when the authenticated user is the commenter
+  IF auth.uid() IS NULL OR auth.uid() <> OLD.user_id THEN
+    RETURN OLD;
+  END IF;
+
+  SELECT user_id INTO v_post_owner
+  FROM public.posts
+  WHERE id = OLD.post_id;
+
+  IF v_post_owner IS NULL OR v_post_owner = OLD.user_id THEN
+    RETURN OLD;
+  END IF;
+
+  -- Guard against account-deletion cascades where either side may be deleted.
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = OLD.user_id) THEN
+    RETURN OLD;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = v_post_owner) THEN
+    RETURN OLD;
+  END IF;
+
+  INSERT INTO public.notifications (user_id, actor_id, type, post_id)
+  VALUES (v_post_owner, OLD.user_id, 'uncomment', OLD.post_id);
+
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, auth;
+
+
+CREATE OR REPLACE FUNCTION public.notify_on_unfollow()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Only create a notification when the authenticated user is the follower
+  IF auth.uid() IS NULL OR auth.uid() <> OLD.follower_id THEN
+    RETURN OLD;
+  END IF;
+
+  IF OLD.follower_id = OLD.following_id THEN
+    RETURN OLD;
+  END IF;
+
+  -- Guard against account-deletion cascades where either side may be deleted.
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = OLD.follower_id) THEN
+    RETURN OLD;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = OLD.following_id) THEN
+    RETURN OLD;
+  END IF;
+
+  INSERT INTO public.notifications (user_id, actor_id, type)
+  VALUES (OLD.following_id, OLD.follower_id, 'unfollow');
+
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, auth;


### PR DESCRIPTION
### Motivation
- Prevent foreign-key violations when account deletions cascade and leave `actor_id`/`user_id` values missing in `auth.users` while AFTER DELETE notification triggers run.
- Ensure negative-notification triggers only create notifications for authenticated actors and when both actor and recipient accounts still exist.

### Description
- Updated `notify_on_unlike`, `notify_on_uncomment`, and `notify_on_unfollow` logic to early-return when the action is a self-action or the post/follow relationship is invalid, instead of attempting an insert.
- Added existence checks against `auth.users` for both the actor and the recipient before inserting into `public.notifications` to guard against account-deletion cascades.
- Adjusted trigger function `search_path` to include `auth` (`SET search_path = public, auth`) so the `auth.users` checks resolve correctly.
- Added a new migration `supabase/migrations/20260426190000_fix_delete_account_notification_fk.sql` that contains the hardened `CREATE OR REPLACE FUNCTION` implementations and explanatory comments for the migration intent.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2be936bc8320bffaf474e5d213d4)