### PR TITLE
Harden notification triggers to avoid FK errors during account-deletes and adjust Vercel routing

### DIFF
--- a/supabase/init.sql
+++ b/supabase/init.sql
@@ -1352,14 +1352,25 @@ BEGIN
   FROM public.posts
   WHERE id = OLD.post_id;
 
-  IF v_post_owner IS NOT NULL AND v_post_owner <> OLD.user_id THEN
-    INSERT INTO public.notifications (user_id, actor_id, type, post_id)
-    VALUES (v_post_owner, OLD.user_id, 'unlike', OLD.post_id);
+  IF v_post_owner IS NULL OR v_post_owner = OLD.user_id THEN
+    RETURN OLD;
   END IF;
+
+  -- Guard against account-deletion cascades where either side may be deleted.
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = OLD.user_id) THEN
+    RETURN OLD;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = v_post_owner) THEN
+    RETURN OLD;
+  END IF;
+
+  INSERT INTO public.notifications (user_id, actor_id, type, post_id)
+  VALUES (v_post_owner, OLD.user_id, 'unlike', OLD.post_id);
 
   RETURN OLD;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, auth;
 
 CREATE TRIGGER on_unlike_notify
   AFTER DELETE ON public.likes
@@ -1399,14 +1410,25 @@ BEGIN
   FROM public.posts
   WHERE id = OLD.post_id;
 
-  IF v_post_owner IS NOT NULL AND v_post_owner <> OLD.user_id THEN
-    INSERT INTO public.notifications (user_id, actor_id, type, post_id)
-    VALUES (v_post_owner, OLD.user_id, 'uncomment', OLD.post_id);
+  IF v_post_owner IS NULL OR v_post_owner = OLD.user_id THEN
+    RETURN OLD;
   END IF;
+
+  -- Guard against account-deletion cascades where either side may be deleted.
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = OLD.user_id) THEN
+    RETURN OLD;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = v_post_owner) THEN
+    RETURN OLD;
+  END IF;
+
+  INSERT INTO public.notifications (user_id, actor_id, type, post_id)
+  VALUES (v_post_owner, OLD.user_id, 'uncomment', OLD.post_id);
 
   RETURN OLD;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, auth;
 
 CREATE TRIGGER on_uncomment_notify
   AFTER DELETE ON public.comments
@@ -1437,14 +1459,25 @@ BEGIN
     RETURN OLD;
   END IF;
 
-  IF OLD.follower_id <> OLD.following_id THEN
-    INSERT INTO public.notifications (user_id, actor_id, type)
-    VALUES (OLD.following_id, OLD.follower_id, 'unfollow');
+  IF OLD.follower_id = OLD.following_id THEN
+    RETURN OLD;
   END IF;
+
+  -- Guard against account-deletion cascades where either side may be deleted.
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = OLD.follower_id) THEN
+    RETURN OLD;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = OLD.following_id) THEN
+    RETURN OLD;
+  END IF;
+
+  INSERT INTO public.notifications (user_id, actor_id, type)
+  VALUES (OLD.following_id, OLD.follower_id, 'unfollow');
 
   RETURN OLD;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, auth;
 
 CREATE TRIGGER on_unfollow_notify
   AFTER DELETE ON public.follows

--- a/supabase/migrations/20260426190000_fix_delete_account_notification_fk.sql
+++ b/supabase/migrations/20260426190000_fix_delete_account_notification_fk.sql
@@ -1,0 +1,107 @@
+-- Prevent FK violations in notifications during account-deletion cascades.
+--
+-- When a user account is deleted, cascading deletes can remove likes/comments/follows
+-- rows and fire AFTER DELETE notification triggers. Those triggers may attempt to
+-- insert notifications with actor_id/follower_id that no longer exists in auth.users,
+-- causing notifications_actor_id_fkey violations.
+--
+-- This migration hardens negative-notification trigger functions by validating
+-- actor and recipient existence in auth.users before inserting notifications.
+
+CREATE OR REPLACE FUNCTION public.notify_on_unlike()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_post_owner UUID;
+BEGIN
+  -- Only create a notification when the authenticated user is the liker
+  IF auth.uid() IS NULL OR auth.uid() <> OLD.user_id THEN
+    RETURN OLD;
+  END IF;
+
+  SELECT user_id INTO v_post_owner
+  FROM public.posts
+  WHERE id = OLD.post_id;
+
+  IF v_post_owner IS NULL OR v_post_owner = OLD.user_id THEN
+    RETURN OLD;
+  END IF;
+
+  -- Guard against account-deletion cascades where either side may be deleted.
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = OLD.user_id) THEN
+    RETURN OLD;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = v_post_owner) THEN
+    RETURN OLD;
+  END IF;
+
+  INSERT INTO public.notifications (user_id, actor_id, type, post_id)
+  VALUES (v_post_owner, OLD.user_id, 'unlike', OLD.post_id);
+
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, auth;
+
+
+CREATE OR REPLACE FUNCTION public.notify_on_uncomment()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_post_owner UUID;
+BEGIN
+  -- Only create a notification when the authenticated user is the commenter
+  IF auth.uid() IS NULL OR auth.uid() <> OLD.user_id THEN
+    RETURN OLD;
+  END IF;
+
+  SELECT user_id INTO v_post_owner
+  FROM public.posts
+  WHERE id = OLD.post_id;
+
+  IF v_post_owner IS NULL OR v_post_owner = OLD.user_id THEN
+    RETURN OLD;
+  END IF;
+
+  -- Guard against account-deletion cascades where either side may be deleted.
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = OLD.user_id) THEN
+    RETURN OLD;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = v_post_owner) THEN
+    RETURN OLD;
+  END IF;
+
+  INSERT INTO public.notifications (user_id, actor_id, type, post_id)
+  VALUES (v_post_owner, OLD.user_id, 'uncomment', OLD.post_id);
+
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, auth;
+
+
+CREATE OR REPLACE FUNCTION public.notify_on_unfollow()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Only create a notification when the authenticated user is the follower
+  IF auth.uid() IS NULL OR auth.uid() <> OLD.follower_id THEN
+    RETURN OLD;
+  END IF;
+
+  IF OLD.follower_id = OLD.following_id THEN
+    RETURN OLD;
+  END IF;
+
+  -- Guard against account-deletion cascades where either side may be deleted.
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = OLD.follower_id) THEN
+    RETURN OLD;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = OLD.following_id) THEN
+    RETURN OLD;
+  END IF;
+
+  INSERT INTO public.notifications (user_id, actor_id, type)
+  VALUES (OLD.following_id, OLD.follower_id, 'unfollow');
+
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, auth;

--- a/vercel.json
+++ b/vercel.json
@@ -81,16 +81,12 @@
             "destination": "/api/bot-render?route=/search"
         },
         {
-            "source": "/post/:postId",
-            "destination": "/api/og?postId=:postId"
-        },
-        {
             "source": "/(auth|about|terms|privacy|search|play|admin|settings)",
             "destination": "/index.html"
         },
         {
             "source": "/stranger",
-            "destination": "/api/og?specialPage=stranger"
+            "destination": "/index.html"
         },
         {
             "source": "/whispers",
@@ -105,13 +101,8 @@
             "destination": "/index.html"
         },
         {
-            "source": "/u/:username",
-            "destination": "/api/og?username=:username"
-        },
-        {
             "source": "/((?!api/|assets/|.*\\..*).*)",
             "destination": "/index.html"
         }
     ]
 }
-


### PR DESCRIPTION
### Motivation

- Prevent foreign-key violations raised by notification triggers firing during account-deletion cascades where actor or recipient rows in `auth.users` may already be removed.
- Ensure negative-notification triggers (`unlike`, `uncomment`, `unfollow`) only create notifications for valid actor/recipient pairs and skip self-actions.
- Simplify routing by disabling a few dynamic OG endpoints and serving the SPA `index.html` for those routes to reduce server-side rendering for those pages.

### Description

- Tightened `public.notify_on_unlike`, `public.notify_on_uncomment`, and `public.notify_on_unfollow` to early-return when the post owner is missing or identical to the actor, and added `NOT EXISTS` checks against `auth.users` for both actor and recipient before inserting into `public.notifications`.
- Updated the functions' `search_path` to include `auth` and kept them `SECURITY DEFINER` to maintain privileges.
- Added a migration `supabase/migrations/20260426190000_fix_delete_account_notification_fk.sql` that replaces the vulnerable trigger functions with the hardened versions to be applied on existing DBs.
- Modified `vercel.json` to remove dynamic OG routes for `/post/:postId` and `/u/:username`, and to serve `/index.html` for `/stranger` (and a few other SPA routes) instead of hitting the OG generator.

### Testing

- Applied the migration against a local Supabase dev instance and verified the updated trigger functions deployed without error.
- Ran the project's automated test suite (`npm test`) and linting/CI checks and observed no regressions; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2be936bc8320bffaf474e5d213d4)