### PR TITLE
Implement maintenance mode via maintenance.json

### DIFF
--- a/api/bot-render.js
+++ b/api/bot-render.js
@@ -1,3 +1,4 @@
+import maintenanceConfig from "../maintenance.json" assert { type: "json" };
 export const config = { runtime: "edge" };
 
 const APP_URL = "https://genjutsu-social.vercel.app";
@@ -347,6 +348,12 @@ async function renderPost(route) {
 }
 
 export default async function handler(req) {
+  if (maintenanceConfig.enabled) {
+    return new Response(JSON.stringify({ ok: false, error: "Service temporarily unavailable" }), {
+      status: 503,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
   const reqUrl = new URL(req.url);
   const route = normalizeRoute(reqUrl.searchParams.get("route") || "/");
 

--- a/api/genjutsu-feed.js
+++ b/api/genjutsu-feed.js
@@ -1,3 +1,4 @@
+import maintenanceConfig from "../maintenance.json" assert { type: "json" };
 export const config = { runtime: "edge" };
 
 const APP_URL = "https://genjutsu-social.vercel.app";
@@ -124,6 +125,12 @@ function normalizePost(post, likesCounts, commentsCounts) {
 }
 
 export default async function handler(req) {
+  if (maintenanceConfig.enabled) {
+    return new Response(JSON.stringify({ ok: false, error: "Service temporarily unavailable" }), {
+      status: 503,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
   if (req.method === "OPTIONS") return jsonResponse({}, 200, "no-store");
   if (req.method !== "GET") return jsonResponse({ ok: false, error: "Method Not Allowed" }, 405, "no-store");
 

--- a/api/link-preview.js
+++ b/api/link-preview.js
@@ -1,3 +1,4 @@
+import maintenanceConfig from "../maintenance.json" assert { type: "json" };
 export const config = { runtime: "edge" };
 
 const REQUEST_TIMEOUT_MS = 7000;
@@ -115,6 +116,12 @@ function jsonResponse(payload, status = 200, cacheControl = "public, max-age=180
 }
 
 export default async function handler(req) {
+  if (maintenanceConfig.enabled) {
+    return new Response(JSON.stringify({ ok: false, error: "Service temporarily unavailable" }), {
+      status: 503,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
   if (req.method === "OPTIONS") {
     return jsonResponse({}, 200, "no-store");
   }

--- a/api/llm-content.js
+++ b/api/llm-content.js
@@ -1,3 +1,4 @@
+import maintenanceConfig from "../maintenance.json" assert { type: "json" };
 export const config = { runtime: "edge" };
 
 function jsonResponse(payload, status = 200) {
@@ -14,6 +15,12 @@ function jsonResponse(payload, status = 200) {
 }
 
 export default async function handler(req) {
+  if (maintenanceConfig.enabled) {
+    return new Response(JSON.stringify({ ok: false, error: "Service temporarily unavailable" }), {
+      status: 503,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
   if (req.method === "OPTIONS") return jsonResponse({}, 200);
   if (req.method !== "GET") return jsonResponse({ error: "Method Not Allowed" }, 405);
 

--- a/api/og.js
+++ b/api/og.js
@@ -1,3 +1,4 @@
+import maintenanceConfig from "../maintenance.json" assert { type: "json" };
 export const config = { runtime: 'edge' };
 
 let SUPABASE_URL = process.env.VITE_SUPABASE_URL;
@@ -16,6 +17,12 @@ function escapeHtml(str) {
 }
 
 export default async function handler(req) {
+    if (maintenanceConfig.enabled) {
+        return new Response(JSON.stringify({ ok: false, error: "Service temporarily unavailable" }), {
+            status: 503,
+            headers: { "Content-Type": "application/json" }
+        });
+    }
     if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {
         const workerUrl = process.env.VITE_CONFIG_WORKER_URL || 'https://genjutsu-config.workers.dev/config';
         try {

--- a/maintenance.json
+++ b/maintenance.json
@@ -1,0 +1,1 @@
+{"enabled": false}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import GoogleAnalytics from "@/components/GoogleAnalytics";
 import { FloatingWhisperBubble } from "@/components/FloatingWhisperBubble";
 import { PushNotificationPrompt } from "@/components/PushNotificationPrompt";
 import MfaSessionGuard from "@/components/MfaSessionGuard";
+import maintenanceConfig from "../maintenance.json";
 
 import Index from "@/pages/Index";
 const AuthPage = lazy(() => import("@/pages/AuthPage"));
@@ -45,7 +46,7 @@ const MfaChallengePage = lazy(() => import("@/pages/MfaChallengePage"));
 const NotFound = lazy(() => import("@/pages/NotFound"));
 
 ////////////////////////////////////////////////////////////////
-const MAINTENANCE_MODE = false; 
+const MAINTENANCE_MODE = maintenanceConfig.enabled;
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
 const queryClient = new QueryClient();


### PR DESCRIPTION
This PR implements a global maintenance mode for the Genjutsu application. 

Key changes:
- Created a `maintenance.json` file in the root directory to control the maintenance status.
- Integrated `maintenance.json` into `src/App.tsx` to toggle the frontend maintenance page.
- Added a maintenance check to the beginning of every API handler in the `api/` directory. When `enabled` is set to `true` in `maintenance.json`, these APIs will return a 503 Service Unavailable response.

To activate maintenance mode, set `"enabled": true` in `maintenance.json` and redeploy.

---
*PR created automatically by Jules for task [12878595414980899714](https://jules.google.com/task/12878595414980899714) started by @iamovi*