### PR TITLE
Public feed: fix page size to 5, cap public pages, add per-IP rate limiting and update docs

### DIFF
--- a/api/genjutsu-feed.js
+++ b/api/genjutsu-feed.js
@@ -1,18 +1,24 @@
 export const config = { runtime: "edge" };
 
 const APP_URL = "https://genjutsu-social.vercel.app";
-const MAX_LIMIT = 50;
-const DEFAULT_LIMIT = 10;
+const FEED_LIMIT = 5;
 const DEFAULT_PAGE = 1;
+const MAX_PUBLIC_PAGE = 3;
 const FEED_WINDOW_HOURS = 24;
 const LIVE_POLL_BUCKET_SECONDS = 30;
 const DEFAULT_CACHE_CONTROL = "public, max-age=30, s-maxage=300, stale-while-revalidate=600";
-const LIVE_CACHE_CONTROL = "public, max-age=5, s-maxage=25, stale-while-revalidate=30";
+const LIVE_CACHE_CONTROL = "public, max-age=15, s-maxage=90, stale-while-revalidate=120";
+
+// Basic in-memory rate limiting (best effort per edge instance)
+const RATE_LIMIT_MAX_REQUESTS = 12;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const rateLimitStore = new Map();
+let lastCleanupAt = 0;
 
 let SUPABASE_URL = process.env.VITE_SUPABASE_URL;
 let SUPABASE_PUBLISHABLE_KEY = process.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 
-function jsonResponse(payload, status = 200, cacheControl = DEFAULT_CACHE_CONTROL) {
+function jsonResponse(payload, status = 200, cacheControl = DEFAULT_CACHE_CONTROL, extraHeaders = {}) {
   return new Response(JSON.stringify(payload), {
     status,
     headers: {
@@ -23,6 +29,7 @@ function jsonResponse(payload, status = 200, cacheControl = DEFAULT_CACHE_CONTRO
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Methods": "GET, OPTIONS",
       "Access-Control-Allow-Headers": "Content-Type",
+      ...extraHeaders,
     },
   });
 }
@@ -51,6 +58,38 @@ function supabaseHeaders() {
     Authorization: `Bearer ${SUPABASE_PUBLISHABLE_KEY}`,
     "Content-Type": "application/json",
   };
+}
+
+
+function getClientIp(req) {
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) return xff.split(",")[0].trim();
+  return req.headers.get("x-real-ip") || "unknown";
+}
+
+function checkRateLimit(ip) {
+  const now = Date.now();
+
+  if (now - lastCleanupAt > RATE_LIMIT_WINDOW_MS) {
+    for (const [key, value] of rateLimitStore.entries()) {
+      const hasRecentHit = (value.hits || []).some((ts) => ts > now - RATE_LIMIT_WINDOW_MS);
+      if (!hasRecentHit) rateLimitStore.delete(key);
+    }
+    lastCleanupAt = now;
+  }
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+  const entry = rateLimitStore.get(ip) || { hits: [] };
+  entry.hits = entry.hits.filter((ts) => ts > windowStart);
+
+  if (entry.hits.length >= RATE_LIMIT_MAX_REQUESTS) {
+    const retryAfterSeconds = Math.max(1, Math.ceil((entry.hits[0] + RATE_LIMIT_WINDOW_MS - now) / 1000));
+    rateLimitStore.set(ip, entry);
+    return { allowed: false, retryAfterSeconds, remaining: 0 };
+  }
+
+  entry.hits.push(now);
+  rateLimitStore.set(ip, entry);
+  return { allowed: true, retryAfterSeconds: 0, remaining: RATE_LIMIT_MAX_REQUESTS - entry.hits.length };
 }
 
 function parsePositiveInt(input, fallback) {
@@ -132,11 +171,30 @@ export default async function handler(req) {
     return jsonResponse({ ok: false, error: "Server configuration error" }, 500, "no-store");
   }
 
+  const clientIp = getClientIp(req);
+  const rateLimit = checkRateLimit(clientIp);
+  if (!rateLimit.allowed) {
+    return jsonResponse(
+      {
+        ok: false,
+        error: "Rate limit exceeded. Please retry shortly.",
+        retry_after_seconds: rateLimit.retryAfterSeconds,
+      },
+      429,
+      "no-store",
+      {
+        "Retry-After": String(rateLimit.retryAfterSeconds),
+        "X-RateLimit-Limit": String(RATE_LIMIT_MAX_REQUESTS),
+        "X-RateLimit-Remaining": "0",
+        "X-RateLimit-Reset": String(Math.ceil(Date.now() / 1000) + rateLimit.retryAfterSeconds),
+      }
+    );
+  }
+
   const url = new URL(req.url);
-  const rawLimit = parsePositiveInt(url.searchParams.get("limit"), DEFAULT_LIMIT);
   const rawPage = parsePositiveInt(url.searchParams.get("page"), DEFAULT_PAGE);
-  const limit = Math.min(rawLimit, MAX_LIMIT);
-  const page = rawPage;
+  const limit = FEED_LIMIT;
+  const page = Math.min(rawPage, MAX_PUBLIC_PAGE);
   const since = url.searchParams.get("since");
   const cutoffIso = buildCutoffIso(since);
   const serverTimeIso = getServerTimeIso();
@@ -209,6 +267,12 @@ export default async function handler(req) {
       meta: {
         page,
         limit,
+        max_public_page: MAX_PUBLIC_PAGE,
+        rate_limit: {
+          max_requests: RATE_LIMIT_MAX_REQUESTS,
+          window_seconds: Math.floor(RATE_LIMIT_WINDOW_MS / 1000),
+          remaining: rateLimit.remaining,
+        },
         has_more: hasMore,
         since: since ? cutoffIso : null,
         window_hours: FEED_WINDOW_HOURS,

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -41,7 +41,7 @@
       <ul>
         <li>Public-only feed data</li>
         <li>24-hour retention window</li>
-        <li>Pagination via <code>page</code> and <code>limit</code></li>
+        <li>Pagination via <code>page</code> (fixed 5 posts per response)</li>
         <li>Live polling support via <code>since</code></li>
       </ul>
     </section>
@@ -50,7 +50,7 @@
       <h2>Beginner Setup (Step by Step)</h2>
       <ol>
         <li>Choose your base URL: <code>https://genjutsu-social.vercel.app</code></li>
-        <li>Build the endpoint URL: <code>/api/genjutsu-feed?page=1&amp;limit=10</code></li>
+        <li>Build the endpoint URL: <code>/api/genjutsu-feed?page=1</code></li>
         <li>Send a <code>GET</code> request using browser fetch, backend code, or cURL.</li>
         <li>Check <code>ok === true</code> before reading <code>posts</code>.</li>
         <li>Render each post card using <code>content</code>, <code>media_url</code>, counts, and <code>profile</code>.</li>
@@ -75,13 +75,7 @@
             <td><code>page</code></td>
             <td>number</td>
             <td>1</td>
-            <td>Page number (1-based).</td>
-          </tr>
-          <tr>
-            <td><code>limit</code></td>
-            <td>number</td>
-            <td>10</td>
-            <td>Posts per page (max 50).</td>
+            <td>Page number (1-based), capped at 3 for public traffic safety.</td>
           </tr>
           <tr>
             <td><code>since</code></td>
@@ -94,7 +88,7 @@
       <p>Validation rules:</p>
       <ul>
         <li><code>page</code> must be a positive integer.</li>
-        <li><code>limit</code> must be a positive integer and is capped at <code>50</code>.</li>
+        <li>Each response is fixed at <code>5</code> posts (the <code>limit</code> query parameter is ignored).</li>
         <li><code>since</code> must be a valid ISO timestamp like <code>2026-04-28T10:30:00.000Z</code>.</li>
         <li>For best cache reuse, pass back <code>meta.server_time</code> instead of generating your own fresh timestamp.</li>
       </ul>
@@ -106,7 +100,13 @@
   "ok": true,
   "meta": {
     "page": 1,
-    "limit": 10,
+    "limit": 5,
+    "max_public_page": 3,
+    "rate_limit": {
+      "max_requests": 12,
+      "window_seconds": 60,
+      "remaining": 11
+    },
     "has_more": true,
     "since": null,
     "window_hours": 24,
@@ -264,6 +264,11 @@
             <td>Upstream data fetch issue while building feed or counts.</td>
             <td><code>{ "ok": false, "error": "Failed to fetch posts" }</code></td>
           </tr>
+          <tr>
+            <td><code>429</code></td>
+            <td>Rate limit exceeded for this IP on this edge instance.</td>
+            <td><code>{ "ok": false, "error": "Rate limit exceeded...", "retry_after_seconds": 12 }</code></td>
+          </tr>
         </tbody>
       </table>
       <p>All error responses follow a JSON shape with <code>ok: false</code> and an <code>error</code> message.</p>
@@ -275,7 +280,7 @@
       <ul>
         <li>Reuse <code>meta.server_time</code> as your next <code>since</code> value.</li>
         <li>Avoid generating a brand new timestamp on every poll.</li>
-        <li>Use small limits for live refreshes whenever possible.</li>
+        <li>Feed size is fixed to 5 posts per request for consistent cache behavior and lower backend load.</li>
       </ul>
     </section>
 
@@ -283,24 +288,24 @@
       <h2>Rate Limits & Fair Use</h2>
       <p>There is no dedicated API key or public per-user quota yet, but consumers should use reasonable polling and caching behavior.</p>
       <ul>
-        <li>Recommended polling interval for live updates: every <strong>10 to 30 seconds</strong>.</li>
+        <li>Recommended polling interval for live updates: every <strong>10 to 30 seconds</strong> (avoid tighter loops).</li>
         <li>Avoid high-frequency loops (for example sub-second polling).</li>
         <li>Use <code>since</code> to fetch only new posts instead of repeatedly requesting large pages.</li>
         <li>Respect caching headers returned by the endpoint when possible.</li>
       </ul>
-      <p>Future versions may enforce hard rate limits and API key-based access controls.</p>
+      <p>The endpoint now enforces a best-effort per-IP rate limit of <code>12 requests / 60 seconds</code> per edge instance, and caps public page requests at <code>page=3</code>.</p>
     </section>
 
     <section class="card">
       <h2>Quick Start</h2>
-      <pre><code>const res = await fetch("https://genjutsu-social.vercel.app/api/genjutsu-feed?limit=10&page=1");
+      <pre><code>const res = await fetch("https://genjutsu-social.vercel.app/api/genjutsu-feed?page=1");
 const data = await res.json();
 console.log(data.posts);</code></pre>
     </section>
 
     <section class="card">
       <h2>cURL Example</h2>
-      <pre><code>curl "https://genjutsu-social.vercel.app/api/genjutsu-feed?page=1&amp;limit=10"</code></pre>
+      <pre><code>curl "https://genjutsu-social.vercel.app/api/genjutsu-feed?page=1"</code></pre>
     </section>
 
     <section class="card">
@@ -309,7 +314,7 @@ console.log(data.posts);</code></pre>
 
 &lt;script&gt;
   async function loadFeed() {
-    const res = await fetch("https://genjutsu-social.vercel.app/api/genjutsu-feed?page=1&amp;limit=10");
+    const res = await fetch("https://genjutsu-social.vercel.app/api/genjutsu-feed?page=1");
     const data = await res.json();
     if (!data.ok) return;
 
@@ -335,8 +340,7 @@ console.log(data.posts);</code></pre>
 async function pollFeed() {
   const url = new URL("https://genjutsu-social.vercel.app/api/genjutsu-feed");
   url.searchParams.set("since", since);
-  url.searchParams.set("limit", "20");
-
+  
   const res = await fetch(url.toString());
   const data = await res.json();
   if (!data.ok) return;
@@ -357,7 +361,7 @@ setInterval(pollFeed, 10000);</code></pre>
       <h2>Common Mistakes</h2>
       <ul>
         <li>Passing invalid <code>since</code> format (must be ISO timestamp).</li>
-        <li>Requesting <code>limit</code> over <code>50</code> and expecting more than the cap.</li>
+        <li>Expecting custom page size via <code>limit</code> (this endpoint always returns up to 5 posts).</li>
         <li>Assuming this endpoint returns data older than 24 hours.</li>
         <li>Not checking <code>ok</code> before reading <code>posts</code>.</li>
         <li>Rendering <code>media_url</code> without null checks.</li>
@@ -383,9 +387,6 @@ setInterval(pollFeed, 10000);</code></pre>
         </label>
         <label>Page
           <input id="page" type="number" min="1" value="1" />
-        </label>
-        <label>Limit
-          <input id="limit" type="number" min="1" max="50" value="10" />
         </label>
         <label>Since (optional)
           <input id="since" type="text" placeholder="2026-04-28T10:30:00.000Z" />

--- a/docs/api/script.js
+++ b/docs/api/script.js
@@ -20,7 +20,6 @@ function renderJson(data) {
 function buildRequestUrl() {
   const baseUrl = (baseUrlInput.value || "").trim().replace(/\/+$/, "");
   const page = (document.getElementById("page").value || "1").trim();
-  const limit = (document.getElementById("limit").value || "10").trim();
   const since = (document.getElementById("since").value || "").trim();
 
   if (!/^https?:\/\//i.test(baseUrl)) {
@@ -29,7 +28,6 @@ function buildRequestUrl() {
 
   const url = new URL("/api/genjutsu-feed", `${baseUrl}/`);
   url.searchParams.set("page", page);
-  url.searchParams.set("limit", limit);
   if (since) url.searchParams.set("since", since);
   return url;
 }


### PR DESCRIPTION
### Motivation
- Reduce backend and cache pressure by fixing the public feed page size and limiting how far anonymous clients can paginate. 
- Provide a best-effort, per-edge-instance protection against abusive polling by adding a lightweight rate limiter and signal useful limits to consumers. 

### Description
- The feed is now fixed to `5` posts per response by replacing `limit` handling with `FEED_LIMIT = 5` and removing the client `limit` parameter, and public requests are capped to `MAX_PUBLIC_PAGE = 3`.
- Added a best-effort in-memory per-edge-instance rate limiter (`RATE_LIMIT_MAX_REQUESTS = 12` per `RATE_LIMIT_WINDOW_MS = 60s`) with `getClientIp` and `checkRateLimit` logic that returns `429` and `Retry-After`/`X-RateLimit-*` headers when exceeded.
- Extended `jsonResponse` to accept `extraHeaders`, surfaced rate-limit info and `max_public_page` in the response `meta`, and adjusted live cache control timings (`LIVE_CACHE_CONTROL` increased).
- Updated API docs and the docs playground (`docs/api/index.html` and `docs/api/script.js`) to remove the `limit` UI, reflect the fixed `5`-post page size, the `page` cap, and the new rate-limit guidance and response schema.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f246caaf78833393b41f31c82e7dd8)