### PR TITLE
Prevent duplicate pagination requests and improve infinite-scroll UX on Index page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -27,17 +27,29 @@ const Index = () => {
   } = usePosts();
   const navigate = useNavigate();
   const observerRef = useRef<HTMLDivElement>(null);
+  const paginationRequestInFlightRef = useRef(false);
+
+  useEffect(() => {
+    paginationRequestInFlightRef.current = isFetchingNextPage;
+  }, [isFetchingNextPage]);
 
   useEffect(() => {
     if (!hasNextPage || isFetchingNextPage) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting) {
-          fetchNextPage();
-        }
+        if (!entries[0]?.isIntersecting) return;
+        if (paginationRequestInFlightRef.current) return;
+
+        paginationRequestInFlightRef.current = true;
+        void fetchNextPage().finally(() => {
+          paginationRequestInFlightRef.current = false;
+        });
       },
-      { threshold: 0.1 }
+      {
+        threshold: 0,
+        rootMargin: "0px 0px 600px 0px",
+      }
     );
 
     if (observerRef.current) {
@@ -106,6 +118,14 @@ const Index = () => {
                     onDelete={deletePost}
                   />
                 ))}
+
+                {isFetchingNextPage && (
+                  <div className="space-y-4" aria-hidden="true">
+                    {[1, 2].map((i) => (
+                      <PostSkeleton key={`next-page-skeleton-${i}`} />
+                    ))}
+                  </div>
+                )}
 
                 <div ref={observerRef} className="h-10 flex justify-center items-center">
                   {isFetchingNextPage && <FrogLoader className=" text-muted-foreground" size={20} />}


### PR DESCRIPTION
### Motivation
- Prevent multiple concurrent pagination requests triggered by the intersection observer when scrolling to the bottom of the feed.
- Improve perceived loading UX for infinite scroll by showing skeleton placeholders and tuning the observer threshold/margin so next pages load earlier.

### Description
- Added a `paginationRequestInFlightRef` ref and an effect to track `isFetchingNextPage` to avoid duplicate `fetchNextPage` calls.
- Updated the `IntersectionObserver` callback to bail out on non-intersecting entries and to guard using `paginationRequestInFlightRef` before calling `fetchNextPage`, setting and clearing the flag around the promise.
- Changed observer options to `threshold: 0` and `rootMargin: "0px 0px 600px 0px"` to prefetch earlier.
- Render a small set of `PostSkeleton` placeholders for the next page and keep the `FrogLoader` in the observer sentinel area, with the skeleton wrapper marked `aria-hidden="true"`.

### Testing
- Ran the frontend test suite with `yarn test` and the tests passed.
- Built the app with `yarn build` to validate the production compile and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4ea67ea04832baa4a61085376a434)