### PR TITLE
Add "Vibrant Night" Theme Preset

### DIFF
--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -5,7 +5,7 @@ type ColorPreset = "purple" | "blue" | "green" | "orange" | "rose" | "zinc" | "c
 type FontPreset = "Reddit Mono" | "Inter" | "Space Grotesk" | "Fira Code" | "JetBrains Mono" | "Comic Neue";
 type RadiusPreset = "none" | "default" | "md" | "lg" | "full";
 export type EmojiPack = "native" | "twemoji" | "google" | "openmoji";
-export type ThemePreset = "default" | "minecraft" | "win95" | "papyrus" | "hackernews" | "winxp" | "gameboy" | "nord" | "terminal";
+export type ThemePreset = "default" | "minecraft" | "win95" | "papyrus" | "hackernews" | "winxp" | "gameboy" | "nord" | "terminal" | "vibrant";
 
 /** Convert a hex color (#rrggbb) to an HSL string "H S% L%" suitable for CSS variables. */
 function hexToHsl(hex: string): string {
@@ -133,7 +133,8 @@ export function ThemeProvider({
     });
     const [preset, setPresetState] = useState<ThemePreset>(() => {
         const stored = localStorage.getItem(`${storageKey}-preset`);
-        if (stored === "minecraft" || stored === "win95" || stored === "papyrus" || stored === "hackernews" || stored === "winxp" || stored === "gameboy" || stored === "nord" || stored === "terminal") {
+        const validPresets: ThemePreset[] = ["default", "minecraft", "win95", "papyrus", "hackernews", "winxp", "gameboy", "nord", "terminal", "vibrant"];
+        if (stored && validPresets.includes(stored as ThemePreset)) {
             return stored as ThemePreset;
         }
         return "default";

--- a/src/index.css
+++ b/src/index.css
@@ -278,6 +278,70 @@ html.dark[data-theme-preset="win95"] {
     --glow: 210 100% 40%;
     --success: 120 100% 40%;
   }
+
+  /* --- Vibrant Night Preset --- */
+  :root[data-theme-preset="vibrant"] {
+    --background: 300 10% 98%;
+    --foreground: 300 10% 3.9%;
+    --card: 300 10% 98%;
+    --card-foreground: 300 10% 3.9%;
+    --popover: 300 10% 98%;
+    --popover-foreground: 300 10% 3.9%;
+    --primary: 300 83% 61%; /* #D946EF Magenta */
+    --primary-foreground: 300 10% 98%;
+    --secondary: 300 10% 90%;
+    --secondary-foreground: 300 10% 3.9%;
+    --muted: 300 10% 95%;
+    --muted-foreground: 300 5% 40%;
+    --accent: 300 10% 90%;
+    --accent-foreground: 300 10% 3.9%;
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 300 10% 85%;
+    --input: 300 10% 85%;
+    --ring: 300 83% 61%;
+    --radius: 16px;
+    --shadow-gum: none;
+    --sidebar-background: 300 10% 98%;
+    --sidebar-foreground: 300 10% 3.9%;
+    --sidebar-primary: 300 83% 61%;
+    --sidebar-primary-foreground: 300 10% 98%;
+    --sidebar-accent: 300 10% 90%;
+    --sidebar-accent-foreground: 300 10% 3.9%;
+    --sidebar-border: 300 10% 85%;
+    --sidebar-ring: 300 83% 61%;
+    --glow: 300 83% 61%;
+    --success: 142 71% 45%;
+  }
+
+  :root.dark[data-theme-preset="vibrant"] {
+    --background: 240 10% 3.9%; /* #09090b */
+    --foreground: 0 0% 98%;
+    --card: 240 6% 10%; /* #18181b */
+    --card-foreground: 0 0% 98%;
+    --popover: 240 10% 3.9%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 300 83% 61%; /* #D946EF Magenta */
+    --primary-foreground: 0 0% 98%;
+    --secondary: 240 6% 15%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 240 6% 15%;
+    --muted-foreground: 240 5% 65%;
+    --accent: 240 6% 15%;
+    --accent-foreground: 0 0% 98%;
+    --border: 240 6% 20%;
+    --input: 240 6% 20%;
+    --ring: 300 83% 61%;
+    --sidebar-background: 240 10% 3.9%;
+    --sidebar-foreground: 0 0% 98%;
+    --sidebar-primary: 300 83% 61%;
+    --sidebar-primary-foreground: 0 0% 98%;
+    --sidebar-accent: 240 6% 15%;
+    --sidebar-accent-foreground: 0 0% 98%;
+    --sidebar-border: 240 6% 20%;
+    --sidebar-ring: 300 83% 61%;
+    --glow: 300 83% 61%;
+  }
 }
 
 @layer base {
@@ -1250,3 +1314,49 @@ html[data-theme-preset="terminal"] ::selection {
   background-color: #00ff41 !important;
   color: #000 !important;
 }
+
+  /* --- Vibrant Night Overrides --- */
+  html[data-theme-preset="vibrant"] body::before {
+    background: radial-gradient(circle at 50% 0%, hsl(var(--primary) / 0.15) 0%, transparent 50%) !important;
+    opacity: 1 !important;
+  }
+
+  html[data-theme-preset="vibrant"] .gum-card {
+    border: 1px solid hsl(var(--border)) !important;
+    box-shadow: 0 4px 24px -1px rgba(0, 0, 0, 0.1), 0 8px 16px -1px rgba(0, 0, 0, 0.1) !important;
+    background-color: hsl(var(--card)) !important;
+    border-radius: 16px !important;
+  }
+
+  html[data-theme-preset="vibrant"] .gum-btn {
+    border-radius: 12px !important;
+    font-weight: 600 !important;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1) !important;
+    border: 1px solid transparent !important;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05) !important;
+  }
+
+  html[data-theme-preset="vibrant"] .gum-btn:hover {
+    transform: translateY(-1px) scale(1.02) !important;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1) !important;
+  }
+
+  html[data-theme-preset="vibrant"] .gum-btn.bg-primary {
+    background-color: hsl(var(--primary)) !important;
+    color: hsl(var(--primary-foreground)) !important;
+    box-shadow: 0 4px 14px 0 hsl(var(--primary) / 0.39) !important;
+  }
+
+  html[data-theme-preset="vibrant"] input,
+  html[data-theme-preset="vibrant"] textarea {
+    border-radius: 12px !important;
+    border: 1px solid hsl(var(--border)) !important;
+    background-color: hsl(var(--background)) !important;
+    transition: all 0.2s ease !important;
+  }
+
+  html[data-theme-preset="vibrant"] input:focus,
+  html[data-theme-preset="vibrant"] textarea:focus {
+    border-color: hsl(var(--primary)) !important;
+    box-shadow: 0 0 0 2px hsl(var(--primary) / 0.1) !important;
+  }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -303,6 +303,16 @@ const SettingsPage = () => {
             setRadius("none");
             setGrid("scanlines");
             setFont("Reddit Mono");
+            return;
+        }
+
+        if (nextPreset === "vibrant") {
+            setColor("custom");
+            setCustomColor("#d946ef");
+            setRadius("lg");
+            setGrid("none");
+            setFont("Inter");
+            return;
         }
     };
 
@@ -832,6 +842,13 @@ const SettingsPage = () => {
                                                     >
                                                         <p className="font-bold text-sm">Terminal</p>
                                                         <p className={`text-xs mt-1 ${preset === "terminal" ? "text-primary-foreground/80" : "text-muted-foreground"}`}>Neon green matrix aesthetic with scanlines</p>
+                                                    </button>
+                                                    <button
+                                                        onClick={() => handlePresetChange("vibrant")}
+                                                        className={`gum-btn text-left px-4 py-3 transition-all ${preset === "vibrant" ? "bg-primary text-primary-foreground gum-shadow-sm" : "bg-background hover:bg-secondary text-foreground"}`}
+                                                    >
+                                                        <p className="font-bold text-sm">Vibrant Night</p>
+                                                        <p className={`text-xs mt-1 ${preset === "vibrant" ? "text-primary-foreground/80" : "text-muted-foreground"}`}>Modern dark theme with neon magenta accents</p>
                                                     </button>
                                                 </div>
                                             </div>


### PR DESCRIPTION
This PR introduces a new "Vibrant Night" theme preset, inspired by modern high-contrast dark UIs with neon accents.

Key changes:
- **Theme Definition**: Added `vibrant` to the `ThemePreset` union and updated `ThemeProvider` to support it.
- **Visual Styles**: Implemented comprehensive CSS overrides for the new preset, including a deep dark background (`#09090b`), neon magenta primary color (`#D946EF`), and increased border radii for a softer, modern feel.
- **Settings Integration**: Added a "Vibrant Night" button to the Appearance tab in the Settings page, allowing users to easily switch to the new look.
- **Verification**: Visually verified the theme via Playwright screenshots, ensuring components like cards, buttons, and inputs align with the new aesthetic.

---
*PR created automatically by Jules for task [4454610362770544523](https://jules.google.com/task/4454610362770544523) started by @iamovi*