### PR TITLE
Migrate project domain to genjutsu.xyz

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -4,7 +4,7 @@
   <p><i>a social network for developers where everything disappears after 24 hours</i></p>
 
 <p>
-    <a href="https://genjutsu-social.vercel.app"><img src="https://img.shields.io/badge/live_app-genjutsu--social.vercel.app-9B78C2?style=flat-square" /></a>
+    <a href="https://genjutsu.xyz"><img src="https://img.shields.io/badge/live_app-genjutsu.xyz-9B78C2?style=flat-square" /></a>
     <a href="https://iamovi.github.io/genjutsu"><img src="https://img.shields.io/badge/download-TWA_Apk-9B78C2?style=flat-square" /></a>
     <a href="https://github.com/iamovi/genjutsu/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-9B78C2?style=flat-square" /></a>
     <a href="https://github.com/iamovi/genjutsu/releases/tag/v2.1.0"><img src="https://img.shields.io/badge/version-2.1.0-9B78C2?style=flat-square" /></a>

--- a/.github/genjutsu-feed-api.md
+++ b/.github/genjutsu-feed-api.md
@@ -4,5 +4,5 @@ Use the public Genjutsu feed API to fetch public posts for your app or website.
 
 Visit the docs site to use the API:
 
-- https://genjutsu-social.vercel.app/api-docs
+- https://genjutsu.xyz/api-docs
 

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -13,4 +13,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ping app
-        run: curl https://genjutsu-social.vercel.app
+        run: curl https://genjutsu.xyz

--- a/api/bot-render.js
+++ b/api/bot-render.js
@@ -1,6 +1,6 @@
 export const config = { runtime: "edge" };
 
-const APP_URL = "https://genjutsu-social.vercel.app";
+const APP_URL = "https://genjutsu.xyz";
 const CONFIG_WORKER_URL = process.env.VITE_CONFIG_WORKER_URL || "https://genjutsu-config.workers.dev/config";
 
 let SUPABASE_URL = process.env.VITE_SUPABASE_URL || "";

--- a/api/genjutsu-feed.js
+++ b/api/genjutsu-feed.js
@@ -2,7 +2,7 @@
 
 export const config = { runtime: "edge" };
 
-const APP_URL = "https://genjutsu-social.vercel.app";
+const APP_URL = "https://genjutsu.xyz";
 const MAX_LIMIT = 50;
 const DEFAULT_LIMIT = 10;
 const DEFAULT_PAGE = 1;

--- a/api/link-preview.js
+++ b/api/link-preview.js
@@ -151,7 +151,7 @@ export default async function handler(req) {
       signal: abortController.signal,
       headers: {
         "user-agent":
-          "Mozilla/5.0 (compatible; GenjutsuLinkPreview/1.0; +https://genjutsu-social.vercel.app)",
+          "Mozilla/5.0 (compatible; GenjutsuLinkPreview/1.0; +https://genjutsu.xyz)",
         accept: "text/html,application/xhtml+xml,image/*,*/*;q=0.8",
       },
     });

--- a/api/llm-content.js
+++ b/api/llm-content.js
@@ -19,7 +19,7 @@ export default async function handler(req) {
 
   const payload = {
     name: "genjutsu",
-    website: "https://genjutsu-social.vercel.app",
+    website: "https://genjutsu.xyz",
     summary:
       "Genjutsu is an ephemeral social platform for developers where posts and whispers expire after 24 hours.",
     features: [
@@ -30,15 +30,15 @@ export default async function handler(req) {
       "Push notifications for social and whisper events",
     ],
     routes: {
-      home: "https://genjutsu-social.vercel.app/",
-      about: "https://genjutsu-social.vercel.app/about",
-      terms: "https://genjutsu-social.vercel.app/terms",
-      privacy: "https://genjutsu-social.vercel.app/privacy",
-      search: "https://genjutsu-social.vercel.app/search",
+      home: "https://genjutsu.xyz/",
+      about: "https://genjutsu.xyz/about",
+      terms: "https://genjutsu.xyz/terms",
+      privacy: "https://genjutsu.xyz/privacy",
+      search: "https://genjutsu.xyz/search",
     },
     machine_readable: {
-      llms_txt: "https://genjutsu-social.vercel.app/llms.txt",
-      sitemap: "https://genjutsu-social.vercel.app/sitemap.xml",
+      llms_txt: "https://genjutsu.xyz/llms.txt",
+      sitemap: "https://genjutsu.xyz/sitemap.xml",
     },
     updated_at: new Date().toISOString(),
   };

--- a/api/og.js
+++ b/api/og.js
@@ -2,7 +2,7 @@ export const config = { runtime: 'edge' };
 
 let SUPABASE_URL = process.env.VITE_SUPABASE_URL;
 let SUPABASE_PUBLISHABLE_KEY = process.env.VITE_SUPABASE_PUBLISHABLE_KEY;
-const APP_URL = 'https://genjutsu-social.vercel.app';
+const APP_URL = 'https://genjutsu.xyz';
 
 // Helper to prevent XSS in injected content
 function escapeHtml(str) {
@@ -21,7 +21,7 @@ export default async function handler(req) {
         try {
             const configRes = await fetch(workerUrl, {
                 headers: {
-                    'Origin': 'https://genjutsu-social.vercel.app'
+                    'Origin': 'https://genjutsu.xyz'
                 }
             });
             if (configRes.ok) {

--- a/cloudflare-worker/index.js
+++ b/cloudflare-worker/index.js
@@ -1,5 +1,6 @@
 const ALLOWED_ORIGINS = [
   "https://genjutsu-social.vercel.app",
+  "https://genjutsu.xyz",
 ];
 
 export default {

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -14,7 +14,7 @@
         <img src="logo.png" alt="Genjutsu logo" class="navbar-logo" />
         <span>Genjutsu API</span>
       </div>
-      <a href="https://genjutsu-social.vercel.app" target="_blank" rel="noopener noreferrer" class="navbar-link">Visit Genjutsu ↗</a>
+      <a href="https://genjutsu.xyz" target="_blank" rel="noopener noreferrer" class="navbar-link">Visit Genjutsu ↗</a>
       <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">
         <svg class="theme-icon moon-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
         <svg class="theme-icon sun-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
@@ -49,7 +49,7 @@
     <section class="card">
       <h2>Beginner Setup (Step by Step)</h2>
       <ol>
-        <li>Choose your base URL: <code>https://genjutsu-social.vercel.app</code></li>
+        <li>Choose your base URL: <code>https://genjutsu.xyz</code></li>
         <li>Build the endpoint URL: <code>/api/genjutsu-feed?page=1&amp;limit=10</code></li>
         <li>Send a <code>GET</code> request using browser fetch, backend code, or cURL.</li>
         <li>Check <code>ok === true</code> before reading <code>posts</code>.</li>
@@ -293,14 +293,14 @@
 
     <section class="card">
       <h2>Quick Start</h2>
-      <pre><code>const res = await fetch("https://genjutsu-social.vercel.app/api/genjutsu-feed?limit=10&page=1");
+      <pre><code>const res = await fetch("https://genjutsu.xyz/api/genjutsu-feed?limit=10&page=1");
 const data = await res.json();
 console.log(data.posts);</code></pre>
     </section>
 
     <section class="card">
       <h2>cURL Example</h2>
-      <pre><code>curl "https://genjutsu-social.vercel.app/api/genjutsu-feed?page=1&amp;limit=10"</code></pre>
+      <pre><code>curl "https://genjutsu.xyz/api/genjutsu-feed?page=1&amp;limit=10"</code></pre>
     </section>
 
     <section class="card">
@@ -309,7 +309,7 @@ console.log(data.posts);</code></pre>
 
 &lt;script&gt;
   async function loadFeed() {
-    const res = await fetch("https://genjutsu-social.vercel.app/api/genjutsu-feed?page=1&amp;limit=10");
+    const res = await fetch("https://genjutsu.xyz/api/genjutsu-feed?page=1&amp;limit=10");
     const data = await res.json();
     if (!data.ok) return;
 
@@ -333,7 +333,7 @@ console.log(data.posts);</code></pre>
       <pre><code>let since = new Date().toISOString();
 
 async function pollFeed() {
-  const url = new URL("https://genjutsu-social.vercel.app/api/genjutsu-feed");
+  const url = new URL("https://genjutsu.xyz/api/genjutsu-feed");
   url.searchParams.set("since", since);
   url.searchParams.set("limit", "20");
 
@@ -379,7 +379,7 @@ setInterval(pollFeed, 10000);</code></pre>
       <h2>Try It</h2>
       <form id="playground-form" class="playground-controls">
         <label>Base URL
-          <input id="base-url" type="url" value="https://genjutsu-social.vercel.app" />
+          <input id="base-url" type="url" value="https://genjutsu.xyz" />
         </label>
         <label>Page
           <input id="page" type="number" min="1" value="1" />

--- a/docs/api/script.js
+++ b/docs/api/script.js
@@ -2,7 +2,7 @@ const form = document.getElementById("playground-form");
 const requestUrlEl = document.getElementById("request-url");
 const responseBox = document.getElementById("response-box");
 const baseUrlInput = document.getElementById("base-url");
-const PROD_BASE_URL = "https://genjutsu-social.vercel.app";
+const PROD_BASE_URL = "https://genjutsu.xyz";
 
 if (typeof window !== "undefined") {
   const isHttp = window.location.protocol === "http:" || window.location.protocol === "https:";

--- a/docs/index.html
+++ b/docs/index.html
@@ -241,7 +241,7 @@
             <a href="#commits" class="mobile-nav-link">Commits</a>
             <a href="#opensource" class="mobile-nav-link">Open Source</a>
             <a href="./api/" target="_blank" class="mobile-nav-link">API Reference ↗</a>
-            <a href="https://genjutsu-social.vercel.app" target="_blank" class="mobile-nav-link">
+            <a href="https://genjutsu.xyz" target="_blank" class="mobile-nav-link">
                 Web App / Enter <i class="ri-external-link-line ml-1"></i>
             </a>
             <a href="https://github.com/iamovi/genjutsu/releases/download/v2.1.0/genjutsu-release.apk"
@@ -302,7 +302,7 @@
                     </div>
                 </div>
             </a>
-            <a href="https://genjutsu-social.vercel.app" target="_blank"
+            <a href="https://genjutsu.xyz" target="_blank"
                 class="gum-btn-ghost inline-flex items-center justify-center gap-3 px-8 py-4 font-bold text-lg w-full sm:w-auto uppercase tracking-wide transition-colors">
                 Open Web App
             </a>
@@ -625,7 +625,7 @@
             class="max-w-6xl mx-auto px-6 flex flex-col md:flex-row items-center justify-between gap-4 font-mono text-sm">
             <p class="text-muted-custom">© 2026 Genjutsu. Everything vanishes.</p>
             <div class="flex items-center gap-6">
-                <a href="https://genjutsu-social.vercel.app" target="_blank"
+                <a href="https://genjutsu.xyz" target="_blank"
                     class="font-bold hover:underline">WEB_APP</a>
                 <a href="./api/" target="_blank" class="font-bold hover:underline">API_DOCS</a>
                 <a href="https://github.com/iamovi/genjutsu" target="_blank"

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>genjutsu / Everything Vanishes</title>
-  <link rel="canonical" href="https://genjutsu-social.vercel.app/" />
+  <link rel="canonical" href="https://genjutsu.xyz/" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta name="description" content="genjutsu - the 24 hour social network. Everything vanishes. Share code, connect with builders." />
   <meta name="keywords" content="genjutsu, developer social network, ephemeral chat, 24 hour posts, coding community" />
@@ -34,8 +34,8 @@
   <meta property="og:title" content="genjutsu / Everything Vanishes" />
   <meta property="og:description" content="The social network where everything vanishes after 24 hours. Share code, connect with developers." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://genjutsu-social.vercel.app/" />
-  <meta property="og:image" content="https://genjutsu-social.vercel.app/og-image.png" />
+  <meta property="og:url" content="https://genjutsu.xyz/" />
+  <meta property="og:image" content="https://genjutsu.xyz/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
 
@@ -43,7 +43,7 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="genjutsu / Everything Vanishes" />
   <meta name="twitter:description" content="Everything vanishes. Social media for developers." />
-  <meta name="twitter:image" content="https://genjutsu-social.vercel.app/og-image.png" />
+  <meta name="twitter:image" content="https://genjutsu.xyz/og-image.png" />
 </head>
 
 <body>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -3,14 +3,14 @@
 Genjutsu is a social platform for developers where most user-generated content is ephemeral and expires after 24 hours.
 
 ## Canonical Site
-- https://genjutsu-social.vercel.app/
+- https://genjutsu.xyz/
 
 ## Public Pages
-- Home: https://genjutsu-social.vercel.app/
-- About: https://genjutsu-social.vercel.app/about
-- Terms: https://genjutsu-social.vercel.app/terms
-- Privacy: https://genjutsu-social.vercel.app/privacy
-- Search: https://genjutsu-social.vercel.app/search
+- Home: https://genjutsu.xyz/
+- About: https://genjutsu.xyz/about
+- Terms: https://genjutsu.xyz/terms
+- Privacy: https://genjutsu.xyz/privacy
+- Search: https://genjutsu.xyz/search
 
 ## Core Product Notes
 - Feed posts disappear after 24 hours.
@@ -20,7 +20,7 @@ Genjutsu is a social platform for developers where most user-generated content i
 - User profiles, likes, comments, and follows are available with moderation controls.
 
 ## Structured Machine Endpoint
-- https://genjutsu-social.vercel.app/api/llm-content
+- https://genjutsu.xyz/api/llm-content
 
 ## Sitemap
-- https://genjutsu-social.vercel.app/sitemap.xml
+- https://genjutsu.xyz/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -71,7 +71,7 @@ Allow: /
 Crawl-delay: 5
 
 # Sitemaps (Good for SEO)
-Sitemap: https://genjutsu-social.vercel.app/sitemap.xml
+Sitemap: https://genjutsu.xyz/sitemap.xml
 
 # Machine-readable docs for LLMs
-# https://genjutsu-social.vercel.app/llms.txt
+# https://genjutsu.xyz/llms.txt

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://genjutsu-social.vercel.app/</loc>
+    <loc>https://genjutsu.xyz/</loc>
     <lastmod>2026-03-02</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://genjutsu-social.vercel.app/search</loc>
+    <loc>https://genjutsu.xyz/search</loc>
     <lastmod>2026-03-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://genjutsu-social.vercel.app/whispers</loc>
+    <loc>https://genjutsu.xyz/whispers</loc>
     <lastmod>2026-03-02</lastmod>
     <changefreq>always</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://genjutsu-social.vercel.app/about</loc>
+    <loc>https://genjutsu.xyz/about</loc>
     <lastmod>2026-03-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://genjutsu-social.vercel.app/privacy</loc>
+    <loc>https://genjutsu.xyz/privacy</loc>
     <lastmod>2026-03-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://genjutsu-social.vercel.app/terms</loc>
+    <loc>https://genjutsu.xyz/terms</loc>
     <lastmod>2026-03-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>

--- a/src/components/WhisperLinkPreview.tsx
+++ b/src/components/WhisperLinkPreview.tsx
@@ -61,7 +61,7 @@ export default function WhisperLinkPreview({ content, isMe }: WhisperLinkPreview
       if (!firstUrl) return null;
       const encoded = encodeURIComponent(firstUrl);
       const localEndpoint = `/api/link-preview?url=${encoded}`;
-      const prodEndpoint = `https://genjutsu-social.vercel.app/api/link-preview?url=${encoded}`;
+      const prodEndpoint = `https://genjutsu.xyz/api/link-preview?url=${encoded}`;
       const endpoints = import.meta.env.DEV ? [localEndpoint, prodEndpoint] : [localEndpoint];
 
       for (const endpoint of endpoints) {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -602,7 +602,7 @@ const SettingsPage = () => {
                                             <div className="pt-6 border-t border-border">
                                                 <h2 className="text-lg font-bold mb-1">{t("settings.changeUsername")}</h2>
                                                 <p className="text-sm text-muted-foreground mb-4">
-                                                    {t("settings.changeUsernameDesc")} <span className="font-mono text-foreground">genjutsu-social.vercel.app/u/{newUsername || "..."}</span>
+                                                    {t("settings.changeUsernameDesc")} <span className="font-mono text-foreground">genjutsu.xyz/u/{newUsername || "..."}</span>
                                                 </p>
                                                 {isOnCooldown && (
                                                     <div className="p-3 mb-4 bg-destructive/10 border border-destructive/20 rounded-[3px] text-sm">

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -15,8 +15,8 @@ self.addEventListener('push', (event: any) => {
   let data = {
     title: 'genjutsu',
     body: 'You got a new notification — open app to see',
-    icon: 'https://genjutsu-social.vercel.app/icon-192x192.png',
-    url: 'https://genjutsu-social.vercel.app',
+    icon: 'https://genjutsu.xyz/icon-192x192.png',
+    url: 'https://genjutsu.xyz',
     tag: '',
     renotify: true,
   };
@@ -78,7 +78,7 @@ self.addEventListener('push', (event: any) => {
       return (self as any).registration.showNotification(data.title, {
         body: notificationBody,
         icon: data.icon,
-        badge: 'https://genjutsu-social.vercel.app/badge-96x96.png',
+        badge: 'https://genjutsu.xyz/badge-96x96.png',
         tag: notificationTag,
         renotify: Boolean(data.renotify),
         data: { url: data.url, history },
@@ -91,13 +91,13 @@ self.addEventListener('push', (event: any) => {
 self.addEventListener('notificationclick', (event: any) => {
   event.notification.close();
 
-  const targetUrl = event.notification.data?.url || 'https://genjutsu-social.vercel.app';
+  const targetUrl = event.notification.data?.url || 'https://genjutsu.xyz';
 
   event.waitUntil(
     (self as any).clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList: any[]) => {
       // If the app is already open, focus it
       for (const client of clientList) {
-        if (client.url.includes('genjutsu-social.vercel.app') && 'focus' in client) {
+        if (client.url.includes('genjutsu.xyz') && 'focus' in client) {
           return client.focus();
         }
       }

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -310,7 +310,7 @@ Deno.serve(async (req) => {
 
     // Build detailed notification message
     let notifBody = "You got a new notification — open app to see";
-    let notifUrl = "https://genjutsu-social.vercel.app";
+    let notifUrl = "https://genjutsu.xyz";
     let notifTag: string | undefined;
 
     if (actorId && notificationType) {
@@ -386,31 +386,31 @@ Deno.serve(async (req) => {
       // Set click URL based on notification type
       if (notificationType === "whisper") {
         if (actorUsername) {
-          notifUrl = `https://genjutsu-social.vercel.app/whisper/${actorUsername}`;
+          notifUrl = `https://genjutsu.xyz/whisper/${actorUsername}`;
         } else {
-          notifUrl = `https://genjutsu-social.vercel.app/whispers`;
+          notifUrl = `https://genjutsu.xyz/whispers`;
         }
       } else if (notificationType === "game_submission") {
-        notifUrl = `https://genjutsu-social.vercel.app/admin`;
+        notifUrl = `https://genjutsu.xyz/admin`;
       } else if (notificationType === "game_approved") {
-        notifUrl = `https://genjutsu-social.vercel.app/game-house`;
+        notifUrl = `https://genjutsu.xyz/game-house`;
       } else if (notificationType === "game_rejected") {
-        notifUrl = `https://genjutsu-social.vercel.app/game-house/submit`;
+        notifUrl = `https://genjutsu.xyz/game-house/submit`;
       } else if ((notificationType === "game_like" || notificationType === "game_comment") && gameId) {
-        notifUrl = `https://genjutsu-social.vercel.app/game-house?game=${gameId}&open=comments`;
+        notifUrl = `https://genjutsu.xyz/game-house?game=${gameId}&open=comments`;
       } else if (notificationType === "follow" || notificationType === "unfollow") {
         if (actorUsername) {
-          notifUrl = `https://genjutsu-social.vercel.app/u/${actorUsername}`;
+          notifUrl = `https://genjutsu.xyz/u/${actorUsername}`;
         }
       } else if (postId) {
-        notifUrl = `https://genjutsu-social.vercel.app/post/${postId}`;
+        notifUrl = `https://genjutsu.xyz/post/${postId}`;
       }
     }
 
     const pushPayload = {
       title: "genjutsu",
       body: notifBody,
-      icon: "https://genjutsu-social.vercel.app/icon-192x192.png",
+      icon: "https://genjutsu.xyz/icon-192x192.png",
       url: notifUrl,
       tag: notifTag,
       renotify: true,


### PR DESCRIPTION
This change performs a full domain migration from the Vercel-provided URL to the custom domain genjutsu.xyz. 

Key changes:
- Replaced `https://genjutsu-social.vercel.app` with `https://genjutsu.xyz` in all API handlers, frontend components, and public assets (robots.txt, sitemap.xml, llms.txt).
- Updated documentation files in `docs/` and project metadata in `index.html`.
- Updated GitHub workflows and project README.
- Added the new domain to `ALLOWED_ORIGINS` in the Cloudflare worker while retaining the old one for compatibility.
- Updated Supabase Edge Functions for push notifications to use the new domain for links.

---
*PR created automatically by Jules for task [5096507045549927992](https://jules.google.com/task/5096507045549927992) started by @iamovi*