### PR TITLE
Add password reset flow, UpdatePassword page, and email/password management in Settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ const AdminPage = lazy(() => import("@/pages/AdminPage"));
 const SettingsPage = lazy(() => import("@/pages/SettingsPage"));
 const StrangerPage = lazy(() => import("@/pages/StrangerPage"));
 const MfaChallengePage = lazy(() => import("@/pages/MfaChallengePage"));
+const UpdatePasswordPage = lazy(() => import("@/pages/UpdatePasswordPage"));
 const GameHouseGallery = lazy(() => import("@/pages/GameHouseGallery"));
 const GameHouseSubmit = lazy(() => import("@/pages/GameHouseSubmit"));
 const GameHouseEdit = lazy(() => import("@/pages/GameHouseEdit"));
@@ -103,6 +104,7 @@ const App = () => {
                       <Route path="/" element={<Index />} />
                       <Route path="/auth" element={<AuthPage />} />
                       <Route path="/auth/mfa" element={<MfaChallengePage />} />
+                      <Route path="/auth/update-password" element={<UpdatePasswordPage />} />
                       <Route path="/about" element={<AboutPage />} />
                       <Route path="/terms" element={<TermsPage />} />
                       <Route path="/privacy" element={<PrivacyPage />} />

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from "react";
-import { User, Session } from "@supabase/supabase-js";
+import { User, Session, UserIdentity } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
 import { isAdminUser } from "@/lib/admin";
 
@@ -13,6 +13,10 @@ interface AuthContextType {
   signInWithGoogle: () => Promise<{ error: any }>;
   signInWithGitHub: () => Promise<{ error: any }>;
   signOut: (options?: { scope?: 'global' | 'local' | 'others' }) => Promise<void>;
+  requestPasswordReset: (email: string) => Promise<{ error: any }>;
+  updatePassword: (password: string) => Promise<{ data: { user: User } | null; error: any }>;
+  updateEmail: (email: string) => Promise<{ data: { user: User } | null; error: any }>;
+  getLinkedIdentities: () => Promise<{ data: { identities: UserIdentity[] } | null; error: any }>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -169,6 +173,31 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
   };
 
+  const requestPasswordReset = async (email: string) => {
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}/auth/update-password`,
+    });
+    return { error };
+  };
+
+  const updatePassword = async (password: string) => {
+    const { data, error } = await supabase.auth.updateUser({ password });
+    return { data, error };
+  };
+
+  const updateEmail = async (email: string) => {
+    const { data, error } = await supabase.auth.updateUser(
+      { email },
+      { emailRedirectTo: `${window.location.origin}/settings?email_change=confirm` }
+    );
+    return { data, error };
+  };
+
+  const getLinkedIdentities = async () => {
+    const { data, error } = await supabase.auth.getUserIdentities();
+    return { data, error };
+  };
+
   return (
     <AuthContext.Provider
       value={{
@@ -181,6 +210,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         signInWithGoogle,
         signInWithGitHub,
         signOut,
+        requestPasswordReset,
+        updatePassword,
+        updateEmail,
+        getLinkedIdentities,
       }}
     >
       {children}

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useAuth } from "@/hooks/useAuth";
 import { Eye, EyeOff, Sparkles, ArrowLeft, Mail } from "lucide-react";
 import { FrogLoader } from "@/components/ui/FrogLoader";
@@ -22,6 +22,7 @@ const signInSchema = z.object({
 const AuthPage = () => {
   const [isSignUp, setIsSignUp] = useState(false);
   const [showEmailForm, setShowEmailForm] = useState(false);
+  const [forgotPasswordMode, setForgotPasswordMode] = useState(false);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [username, setUsername] = useState("");
@@ -31,10 +32,21 @@ const AuthPage = () => {
   const [success, setSuccess] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
-  const { signIn, signUp, signInWithGoogle, signInWithGitHub } = useAuth();
+  const { signIn, signUp, signInWithGoogle, signInWithGitHub, requestPasswordReset } = useAuth();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [googleLoading, setGoogleLoading] = useState(false);
   const [githubLoading, setGithubLoading] = useState(false);
+
+  useEffect(() => {
+    if (searchParams.get("mode") === "reset") {
+      setShowEmailForm(true);
+      setForgotPasswordMode(true);
+      setIsSignUp(false);
+      setError("");
+      setSuccess("");
+    }
+  }, [searchParams]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -43,7 +55,19 @@ const AuthPage = () => {
     setSubmitting(true);
 
     try {
-      if (isSignUp) {
+      if (forgotPasswordMode) {
+        const parsed = z.string().trim().email("Invalid email address").max(255).parse(email);
+        const { error } = await requestPasswordReset(parsed);
+        if (error) {
+          if (error.message?.toLowerCase().includes("rate limit") || error.message?.toLowerCase().includes("too many requests")) {
+            setError("Password reset email limit reached. Please try again later.");
+          } else {
+            setError(error.message || "Password reset request failed");
+          }
+        } else {
+          setSuccess("If an account exists for this email, a password reset link has been sent. Check your inbox and spam folder.");
+        }
+      } else if (isSignUp) {
         const parsed = signUpSchema.parse({ email, password, username, displayName });
         const { data, error } = await signUp(parsed.email, parsed.password, parsed.username, parsed.displayName);
         if (error) {
@@ -281,7 +305,7 @@ const AuthPage = () => {
                     </div>
 
                     <button
-                      onClick={() => { setShowEmailForm(true); setError(""); setSuccess(""); }}
+                      onClick={() => { setShowEmailForm(true); setForgotPasswordMode(false); setError(""); setSuccess(""); }}
                       className="w-full gum-btn bg-background gum-border text-sm py-4 flex items-center justify-center gap-3 hover:bg-secondary hover:shadow-md transition-all active:scale-[0.98]"
                     >
                       <Mail size={20} />
@@ -299,30 +323,38 @@ const AuthPage = () => {
                   >
                     <button
                       type="button"
-                      onClick={() => { setShowEmailForm(false); setError(""); setSuccess(""); }}
+                      onClick={() => { setShowEmailForm(false); setForgotPasswordMode(false); setError(""); setSuccess(""); }}
                       className="inline-flex items-center gap-2 text-sm font-bold text-muted-foreground hover:text-foreground transition-colors mb-6 group"
                     >
                       <ArrowLeft size={16} className="group-hover:-translate-x-1 transition-transform" />
                       All sign in options
                     </button>
 
-                    <div className="flex p-1 bg-secondary rounded-[3px] mb-8">
-                      {["Sign In", "Sign Up"].map((tab, i) => (
-                        <button
-                          key={tab}
-                          onClick={() => { setIsSignUp(i === 1); setError(""); setSuccess(""); }}
-                          className={`flex-1 py-3 text-sm font-bold rounded-[3px] transition-all duration-300 ${(i === 0 && !isSignUp) || (i === 1 && isSignUp)
-                            ? "bg-background text-foreground shadow-md scale-[1.02]"
-                            : "text-muted-foreground hover:text-foreground"
-                            }`}
-                        >
-                          {tab}
-                        </button>
-                      ))}
-                    </div>
+                    {!forgotPasswordMode ? (
+                      <div className="flex p-1 bg-secondary rounded-[3px] mb-8">
+                        {["Sign In", "Sign Up"].map((tab, i) => (
+                          <button
+                            key={tab}
+                            type="button"
+                            onClick={() => { setIsSignUp(i === 1); setError(""); setSuccess(""); }}
+                            className={`flex-1 py-3 text-sm font-bold rounded-[3px] transition-all duration-300 ${(i === 0 && !isSignUp) || (i === 1 && isSignUp)
+                              ? "bg-background text-foreground shadow-md scale-[1.02]"
+                              : "text-muted-foreground hover:text-foreground"
+                              }`}
+                          >
+                            {tab}
+                          </button>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="mb-8 text-center space-y-2">
+                        <h2 className="text-xl font-black">Reset Password</h2>
+                        <p className="text-sm text-muted-foreground">Enter your email and we'll send you a secure reset link.</p>
+                      </div>
+                    )}
 
                     <form onSubmit={handleSubmit} className="space-y-5">
-                      {isSignUp && (
+                      {isSignUp && !forgotPasswordMode && (
                         <motion.div
                           initial={{ opacity: 0, height: 0 }}
                           animate={{ opacity: 1, height: "auto" }}
@@ -379,31 +411,42 @@ const AuthPage = () => {
                         />
                       </div>
 
-                      <div>
-                        <label className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground/60 mb-2 block">
-                          Password
-                        </label>
-                        <div className="relative">
-                          <input
-                            id="password"
-                            name="password"
-                            type={showPassword ? "text" : "password"}
-                            value={password}
-                            onChange={(e) => setPassword(e.target.value)}
-                            placeholder="••••••••"
-                            className="w-full px-4 py-3 bg-secondary/30 gum-border rounded-[3px] text-sm outline-none focus:ring-2 focus:ring-primary/20 pr-12 transition-all placeholder:text-muted-foreground/30"
-                            required
-                            autoComplete={isSignUp ? "new-password" : "current-password"}
-                          />
-                          <button
-                            type="button"
-                            onClick={() => setShowPassword(!showPassword)}
-                            className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                          >
-                            {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-                          </button>
+                      {!forgotPasswordMode && (
+                        <div>
+                          <label className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground/60 mb-2 block">
+                            Password
+                          </label>
+                          <div className="relative">
+                            <input
+                              id="password"
+                              name="password"
+                              type={showPassword ? "text" : "password"}
+                              value={password}
+                              onChange={(e) => setPassword(e.target.value)}
+                              placeholder="••••••••"
+                              className="w-full px-4 py-3 bg-secondary/30 gum-border rounded-[3px] text-sm outline-none focus:ring-2 focus:ring-primary/20 pr-12 transition-all placeholder:text-muted-foreground/30"
+                              required
+                              autoComplete={isSignUp ? "new-password" : "current-password"}
+                            />
+                            <button
+                              type="button"
+                              onClick={() => setShowPassword(!showPassword)}
+                              className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                            >
+                              {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                            </button>
+                          </div>
+                          {!isSignUp && (
+                            <button
+                              type="button"
+                              onClick={() => { setForgotPasswordMode(true); setError(""); setSuccess(""); }}
+                              className="mt-3 text-xs font-bold text-primary hover:underline"
+                            >
+                              Forgot password?
+                            </button>
+                          )}
                         </div>
-                      </div>
+                      )}
 
                       {error && (
                         <motion.div
@@ -435,8 +478,18 @@ const AuthPage = () => {
                             <FrogLoader size={16} />
                             Processing...
                           </span>
-                        ) : isSignUp ? "Create Account" : "Sign In"}
+                        ) : forgotPasswordMode ? "Send Reset Link" : isSignUp ? "Create Account" : "Sign In"}
                       </button>
+
+                      {forgotPasswordMode && (
+                        <button
+                          type="button"
+                          onClick={() => { setForgotPasswordMode(false); setError(""); setSuccess(""); navigate("/auth", { replace: true }); }}
+                          className="w-full text-xs font-bold text-muted-foreground hover:text-foreground transition-colors"
+                        >
+                          Back to sign in
+                        </button>
+                      )}
                     </form>
                   </motion.div>
                 )}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -52,7 +52,7 @@ const buildQrImageSrc = (qrCode: string) => {
 };
 
 const SettingsPage = () => {
-    const { user, signOut, isAdmin } = useAuth();
+    const { user, signOut, isAdmin, updateEmail, updatePassword, getLinkedIdentities } = useAuth();
     const { profile, changeUsername, getNextUsernameChangeDate, deleteAccount } = useProfile();
     const navigate = useNavigate();
     const { t, i18n } = useTranslation();
@@ -66,6 +66,16 @@ const SettingsPage = () => {
     const [mfaAalLevel, setMfaAalLevel] = useState<"aal1" | "aal2" | null>(null);
     const [mfaSetup, setMfaSetup] = useState<MfaSetupState | null>(null);
     const [mfaCode, setMfaCode] = useState("");
+
+    const [newEmail, setNewEmail] = useState("");
+    const [emailActionLoading, setEmailActionLoading] = useState(false);
+    const [authSecurityLoading, setAuthSecurityLoading] = useState(false);
+    const [authSecurityError, setAuthSecurityError] = useState<string | null>(null);
+    const [linkedProviders, setLinkedProviders] = useState<string[]>([]);
+    const [accountPassword, setAccountPassword] = useState("");
+    const [accountPasswordConfirm, setAccountPasswordConfirm] = useState("");
+    const [showAccountPassword, setShowAccountPassword] = useState(false);
+    const [passwordActionLoading, setPasswordActionLoading] = useState(false);
 
     const [newUsername, setNewUsername] = useState("");
     const [usernameError, setUsernameError] = useState<string | null>(null);
@@ -143,6 +153,10 @@ const SettingsPage = () => {
             setNewUsername(profile.username);
         }
     }, [profile?.username]);
+
+    useEffect(() => {
+        setNewEmail(user?.email ?? "");
+    }, [user?.email]);
 
     // Handle session expiration or manual logout
     useEffect(() => {
@@ -336,11 +350,30 @@ const SettingsPage = () => {
         }
     }, [user]);
 
+    const loadAuthSecurityStatus = useCallback(async () => {
+        if (!user) return;
+
+        setAuthSecurityLoading(true);
+        setAuthSecurityError(null);
+        try {
+            const { data, error } = await getLinkedIdentities();
+            if (error) throw error;
+            setLinkedProviders([...(new Set((data?.identities ?? []).map((identity) => identity.provider)))]);
+        } catch (error: any) {
+            console.error("Failed to load linked sign-in methods:", error);
+            setAuthSecurityError("Couldn't load linked sign-in methods.");
+            setLinkedProviders([]);
+        } finally {
+            setAuthSecurityLoading(false);
+        }
+    }, [getLinkedIdentities, user]);
+
     useEffect(() => {
         if (activeTab === "security") {
             void loadMfaStatus();
+            void loadAuthSecurityStatus();
         }
-    }, [activeTab, loadMfaStatus]);
+    }, [activeTab, loadMfaStatus, loadAuthSecurityStatus]);
 
     const handleStartMfaSetup = async () => {
         if (!mfaStatusReady || mfaStatusLoading || mfaActionLoading || !!mfaSetup) return;
@@ -453,6 +486,82 @@ const SettingsPage = () => {
             setMfaActionLoading(false);
         }
     };
+
+
+    const validateEmail = (value: string): string | null => {
+        const normalized = value.trim();
+        if (!normalized) return "Email is required";
+        if (normalized.length > 255) return "Email must be 255 characters or less";
+        if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized)) return "Enter a valid email address";
+        if (user?.email && normalized.toLowerCase() === user.email.toLowerCase()) return "Enter a different email address";
+        return null;
+    };
+
+    const validateAccountPassword = (): string | null => {
+        if (accountPassword.length < 6) return "Password must be at least 6 characters";
+        if (accountPassword.length > 72) return "Password must be 72 characters or less";
+        if (accountPassword !== accountPasswordConfirm) return "Passwords do not match";
+        return null;
+    };
+
+    const handleUpdateEmail = async () => {
+        const validationError = validateEmail(newEmail);
+        if (validationError) {
+            toast.error(validationError);
+            return;
+        }
+
+        setEmailActionLoading(true);
+        const { error } = await updateEmail(newEmail.trim());
+        setEmailActionLoading(false);
+
+        if (error) {
+            const message = String(error.message || "").toLowerCase();
+            if (message.includes("rate limit") || message.includes("too many requests")) {
+                toast.error("Email change limit reached. Please try again later.");
+            } else if (message.includes("already") || message.includes("exists")) {
+                toast.error("That email is already in use. Try a different address.");
+            } else {
+                toast.error(error.message || "Couldn't start email change.");
+            }
+            return;
+        }
+
+        toast.success("Confirmation email sent. Check your new email, and your current email too if secure email change is enabled.");
+    };
+
+    const handleUpdateAccountPassword = async () => {
+        const validationError = validateAccountPassword();
+        if (validationError) {
+            toast.error(validationError);
+            return;
+        }
+
+        setPasswordActionLoading(true);
+        const { error } = await updatePassword(accountPassword);
+        setPasswordActionLoading(false);
+
+        if (error) {
+            const message = String(error.message || "").toLowerCase();
+            if (message.includes("rate limit") || message.includes("too many requests")) {
+                toast.error("Password update limit reached. Please try again later.");
+            } else if (message.includes("reauth") || message.includes("nonce") || message.includes("session")) {
+                toast.error("Please sign in again, then retry the password update.");
+            } else {
+                toast.error(error.message || "Couldn't update password.");
+            }
+            return;
+        }
+
+        setAccountPassword("");
+        setAccountPasswordConfirm("");
+        toast.success(hasEmailIdentity ? "Password updated." : "Password added. You can now sign in with email and password.");
+        await loadAuthSecurityStatus();
+    };
+
+    const metadataProviders = Array.isArray(user.app_metadata?.providers) ? user.app_metadata.providers as string[] : [];
+    const hasEmailIdentity = linkedProviders.includes("email") || user.app_metadata?.provider === "email" || metadataProviders.includes("email");
+    const oauthProviders = (linkedProviders.length > 0 ? linkedProviders : metadataProviders).filter((provider) => provider === "google" || provider === "github");
 
     if (!user) {
         return null;
@@ -1133,6 +1242,147 @@ const SettingsPage = () => {
                                                     <KeyRound className="text-primary" />
                                                     Security
                                                 </h2>
+
+                                                {/* Account Email */}
+                                                <div className="bg-secondary/30 p-4 rounded-[3px] border border-border space-y-4">
+                                                    <div>
+                                                        <h3 className="font-bold mb-1 flex items-center gap-2">
+                                                            <AtSign size={18} className="text-primary" />
+                                                            Email Address
+                                                        </h3>
+                                                        <p className="text-sm text-muted-foreground">
+                                                            Change the email used for sign-in and account notifications. Supabase will send confirmation email before applying the change.
+                                                        </p>
+                                                    </div>
+                                                    <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-end">
+                                                        <div>
+                                                            <label className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground/60 mb-2 block">
+                                                                Current email
+                                                            </label>
+                                                            <input
+                                                                type="email"
+                                                                value={newEmail}
+                                                                onChange={(e) => setNewEmail(e.target.value)}
+                                                                className="w-full px-4 py-3 bg-background gum-border rounded-[3px] text-sm outline-none focus:ring-2 focus:ring-primary/20 transition-all placeholder:text-muted-foreground/30"
+                                                                placeholder={user.email ?? "you@dev.com"}
+                                                                autoComplete="email"
+                                                            />
+                                                        </div>
+                                                        <button
+                                                            type="button"
+                                                            onClick={handleUpdateEmail}
+                                                            disabled={emailActionLoading || !newEmail.trim() || newEmail.trim().toLowerCase() === (user.email ?? "").toLowerCase()}
+                                                            className="gum-btn bg-primary text-primary-foreground px-4 py-3 text-sm font-bold disabled:opacity-50"
+                                                        >
+                                                            {emailActionLoading ? <FrogLoader size={16} className="" /> : "Change Email"}
+                                                        </button>
+                                                    </div>
+                                                    <p className="text-[11px] text-muted-foreground">
+                                                        If secure email change is enabled, you must confirm from both your current and new inbox.
+                                                    </p>
+                                                </div>
+
+                                                {/* Password Sign-in */}
+                                                <div className="bg-secondary/30 p-4 rounded-[3px] border border-border space-y-4">
+                                                    <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+                                                        <div>
+                                                            <h3 className="font-bold mb-1 flex items-center gap-2">
+                                                                <KeyRound size={18} className={hasEmailIdentity ? "text-primary" : "text-muted-foreground"} />
+                                                                {hasEmailIdentity ? "Change Password" : "Add Password"}
+                                                            </h3>
+                                                            <p className="text-sm text-muted-foreground">
+                                                                {hasEmailIdentity
+                                                                    ? "Update your email/password sign-in password."
+                                                                    : "You joined with Google or GitHub. Add a password to also sign in with email."}
+                                                            </p>
+                                                        </div>
+                                                        <div className="flex flex-wrap gap-2">
+                                                            {authSecurityLoading ? (
+                                                                <span className="inline-flex items-center gap-2 text-xs font-bold text-muted-foreground">
+                                                                    <FrogLoader size={14} className="" /> Loading methods
+                                                                </span>
+                                                            ) : linkedProviders.length > 0 ? (
+                                                                linkedProviders.map((provider) => (
+                                                                    <span key={provider} className="rounded-[3px] border border-border bg-background px-2 py-1 text-[10px] font-black uppercase tracking-widest">
+                                                                        {provider}
+                                                                    </span>
+                                                                ))
+                                                            ) : (
+                                                                <span className="rounded-[3px] border border-border bg-background px-2 py-1 text-[10px] font-black uppercase tracking-widest">
+                                                                    {user.app_metadata?.provider ?? "auth"}
+                                                                </span>
+                                                            )}
+                                                        </div>
+                                                    </div>
+
+                                                    {authSecurityError && (
+                                                        <div className="flex items-center justify-between gap-3 rounded-[3px] border border-destructive/30 bg-destructive/10 px-3 py-2">
+                                                            <p className="text-xs font-medium text-destructive">{authSecurityError}</p>
+                                                            <button
+                                                                onClick={() => void loadAuthSecurityStatus()}
+                                                                className="gum-btn bg-background px-3 py-1.5 text-xs font-bold"
+                                                                disabled={authSecurityLoading}
+                                                            >
+                                                                Retry
+                                                            </button>
+                                                        </div>
+                                                    )}
+
+                                                    {!hasEmailIdentity && oauthProviders.length > 0 && (
+                                                        <div className="rounded-[3px] border border-primary/20 bg-primary/10 px-3 py-2 text-xs font-bold text-foreground">
+                                                            Adding a password keeps your {oauthProviders.join("/")} sign-in connected and adds email/password as another option.
+                                                        </div>
+                                                    )}
+
+                                                    <div className="grid gap-3 sm:grid-cols-2">
+                                                        <div>
+                                                            <label className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground/60 mb-2 block">
+                                                                New password
+                                                            </label>
+                                                            <div className="relative">
+                                                                <input
+                                                                    type={showAccountPassword ? "text" : "password"}
+                                                                    value={accountPassword}
+                                                                    onChange={(e) => setAccountPassword(e.target.value)}
+                                                                    className="w-full px-4 py-3 bg-background gum-border rounded-[3px] text-sm outline-none focus:ring-2 focus:ring-primary/20 pr-12 transition-all placeholder:text-muted-foreground/30"
+                                                                    placeholder="••••••••"
+                                                                    autoComplete="new-password"
+                                                                />
+                                                                <button
+                                                                    type="button"
+                                                                    onClick={() => setShowAccountPassword(!showAccountPassword)}
+                                                                    className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                                                                >
+                                                                    {showAccountPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                                                                </button>
+                                                            </div>
+                                                        </div>
+                                                        <div>
+                                                            <label className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground/60 mb-2 block">
+                                                                Confirm password
+                                                            </label>
+                                                            <input
+                                                                type={showAccountPassword ? "text" : "password"}
+                                                                value={accountPasswordConfirm}
+                                                                onChange={(e) => setAccountPasswordConfirm(e.target.value)}
+                                                                className="w-full px-4 py-3 bg-background gum-border rounded-[3px] text-sm outline-none focus:ring-2 focus:ring-primary/20 transition-all placeholder:text-muted-foreground/30"
+                                                                placeholder="••••••••"
+                                                                autoComplete="new-password"
+                                                            />
+                                                        </div>
+                                                    </div>
+
+                                                    <div className="flex justify-end">
+                                                        <button
+                                                            type="button"
+                                                            onClick={handleUpdateAccountPassword}
+                                                            disabled={passwordActionLoading || !accountPassword || !accountPasswordConfirm}
+                                                            className="gum-btn bg-primary text-primary-foreground px-4 py-3 text-sm font-bold disabled:opacity-50"
+                                                        >
+                                                            {passwordActionLoading ? <FrogLoader size={16} className="" /> : hasEmailIdentity ? "Update Password" : "Add Password"}
+                                                        </button>
+                                                    </div>
+                                                </div>
 
                                                 {/* Authenticator App (2FA) */}
                                                 <div className="bg-secondary/30 p-4 rounded-[3px] border border-border space-y-4">

--- a/src/pages/UpdatePasswordPage.tsx
+++ b/src/pages/UpdatePasswordPage.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Eye, EyeOff, KeyRound, ArrowLeft } from "lucide-react";
+import { Helmet } from "react-helmet-async";
+import { toast } from "sonner";
+import { z } from "zod";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/hooks/useAuth";
+import { FrogLoader } from "@/components/ui/FrogLoader";
+
+const passwordSchema = z
+  .object({
+    password: z.string().min(6, "Password must be at least 6 characters").max(72),
+    confirmPassword: z.string().min(1, "Confirm your new password"),
+  })
+  .refine((value) => value.password === value.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+const UpdatePasswordPage = () => {
+  const navigate = useNavigate();
+  const { updatePassword } = useAuth();
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [checkingSession, setCheckingSession] = useState(true);
+  const [hasRecoverySession, setHasRecoverySession] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!mounted) return;
+      setHasRecoverySession(!!session);
+      setCheckingSession(false);
+    });
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+      if (!mounted) return;
+      if (event === "PASSWORD_RECOVERY" || session) {
+        setHasRecoverySession(true);
+      }
+      setCheckingSession(false);
+    });
+
+    return () => {
+      mounted = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError("");
+    setSubmitting(true);
+
+    try {
+      const parsed = passwordSchema.parse({ password, confirmPassword });
+      const { error } = await updatePassword(parsed.password);
+
+      if (error) {
+        const message = String(error.message || "").toLowerCase();
+        if (message.includes("session") || message.includes("expired")) {
+          setError("This reset link is expired or invalid. Request a new password reset email.");
+        } else if (message.includes("rate limit") || message.includes("too many requests")) {
+          setError("Password update limit reached. Please try again later.");
+        } else {
+          setError(error.message || "Could not update password.");
+        }
+        return;
+      }
+
+      toast.success("Password updated. You're signed in with your new password.");
+      navigate("/", { replace: true });
+    } catch (err: any) {
+      if (err instanceof z.ZodError) {
+        setError(err.errors[0].message);
+      } else {
+        setError("Something went wrong. Please try again.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background text-foreground flex items-center justify-center p-4">
+      <Helmet>
+        <title>Update Password — genjutsu</title>
+        <meta name="description" content="Set a new password for your genjutsu account." />
+      </Helmet>
+
+      <div className="w-full max-w-md gum-card p-8 space-y-6">
+        <button
+          type="button"
+          onClick={() => navigate("/auth")}
+          className="inline-flex items-center gap-2 text-sm font-bold text-muted-foreground hover:text-foreground transition-colors group"
+        >
+          <ArrowLeft size={16} className="group-hover:-translate-x-1 transition-transform" />
+          Back to sign in
+        </button>
+
+        <div className="text-center space-y-3">
+          <div className="mx-auto w-12 h-12 rounded-[3px] gum-card bg-secondary flex items-center justify-center">
+            <KeyRound size={22} className="text-primary" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-black">Set New Password</h1>
+            <p className="text-sm text-muted-foreground mt-2">
+              Create a fresh password for your account. Reset links can only be used once.
+            </p>
+          </div>
+        </div>
+
+        {checkingSession ? (
+          <div className="flex justify-center py-8">
+            <FrogLoader size={24} />
+          </div>
+        ) : !hasRecoverySession ? (
+          <div className="space-y-4">
+            <div className="text-sm font-bold bg-destructive/10 text-destructive px-4 py-3 rounded-[3px] border-2 border-destructive/20">
+              This password reset link is expired or invalid. Please request a new reset email.
+            </div>
+            <button
+              type="button"
+              onClick={() => navigate("/auth?mode=reset")}
+              className="w-full gum-btn bg-primary text-primary-foreground text-sm py-3 font-bold"
+            >
+              Request a New Link
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <div>
+              <label className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground/60 mb-2 block">
+                New Password
+              </label>
+              <div className="relative">
+                <input
+                  id="new-password"
+                  name="new-password"
+                  type={showPassword ? "text" : "password"}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="••••••••"
+                  className="w-full px-4 py-3 bg-secondary/30 gum-border rounded-[3px] text-sm outline-none focus:ring-2 focus:ring-primary/20 pr-12 transition-all placeholder:text-muted-foreground/30"
+                  required
+                  autoComplete="new-password"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground/60 mb-2 block">
+                Confirm Password
+              </label>
+              <input
+                id="confirm-password"
+                name="confirm-password"
+                type={showPassword ? "text" : "password"}
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                placeholder="••••••••"
+                className="w-full px-4 py-3 bg-secondary/30 gum-border rounded-[3px] text-sm outline-none focus:ring-2 focus:ring-primary/20 transition-all placeholder:text-muted-foreground/30"
+                required
+                autoComplete="new-password"
+              />
+            </div>
+
+            {error && (
+              <div className="text-xs font-bold bg-destructive/10 text-destructive px-4 py-3 rounded-[3px] border-2 border-destructive/20">
+                {error}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full gum-btn bg-primary text-primary-foreground text-sm py-4 font-bold shadow-lg hover:shadow-xl active:scale-[0.98] transition-all disabled:opacity-50"
+            >
+              {submitting ? (
+                <span className="flex items-center justify-center gap-2">
+                  <FrogLoader size={16} />
+                  Updating...
+                </span>
+              ) : "Update Password"}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default UpdatePasswordPage;


### PR DESCRIPTION
### Motivation
- Add end-to-end support for password recovery and in-app account credential management so users can request a reset link, set a new password from the recovery session, change their email, and add/update an account password.
- Expose Supabase identity metadata to show linked sign-in providers and adapt UI flows for OAuth-only accounts.

### Description
- Added `UpdatePasswordPage` and wired the route at `/auth/update-password` in `App.tsx` to handle password recovery sessions and allow setting a new password.`
- Extended the auth context in `src/hooks/useAuth.tsx` with `requestPasswordReset`, `updatePassword`, `updateEmail`, and `getLinkedIdentities` to call Supabase auth APIs.
- Enhanced `AuthPage` to provide a "Forgot password" / reset email flow that triggers `requestPasswordReset` and supports opening the email form via `?mode=reset`.
- Expanded `SettingsPage` to support changing account email, adding/updating a password for OAuth accounts, showing linked providers, and improved validation and UX for these security actions.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06fdc965d0832b8197180008f5f429)