### PR TITLE
Stranger chat: UI revamp, interest-based matchmaking, Ably refactor and message safeguards

### DIFF
--- a/src/components/stranger/MessageList.tsx
+++ b/src/components/stranger/MessageList.tsx
@@ -1,31 +1,49 @@
 import { Message } from "./useStrangerMatch";
 import { useEffect, useRef } from "react";
 import { format } from "date-fns";
+import { Bot, ShieldCheck, TriangleAlert } from "lucide-react";
+
+const systemToneClass: Record<NonNullable<Message['tone']>, string> = {
+  default: "bg-secondary/80 text-secondary-foreground border-border",
+  success: "bg-green-500/15 text-green-700 dark:text-green-300 border-green-500/40",
+  warning: "bg-yellow-500/15 text-yellow-700 dark:text-yellow-300 border-yellow-500/40",
+  danger: "bg-destructive/15 text-destructive border-destructive/40",
+};
 
 export const MessageList = ({ messages, isStrangerTyping }: { messages: Message[], isStrangerTyping?: boolean }) => {
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   }, [messages, isStrangerTyping]);
 
   if (messages.length === 0) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground p-8 text-center bg-background/50 rounded-[3px] gum-border mx-4">
-        <p className="font-bold mb-2">You are now chatting with a random stranger.</p>
-        <p className="text-sm">Say hi!</p>
+      <div className="flex-1 min-h-0 overflow-y-auto p-3 sm:p-5">
+        <div className="h-full min-h-[260px] flex flex-col items-center justify-center text-center bg-background/60 rounded-[3px] gum-border border-dashed p-6">
+          <div className="w-14 h-14 rounded-[3px] gum-border bg-primary/10 text-primary flex items-center justify-center mb-4 shadow-[3px_3px_0_theme(colors.border)]">
+            <Bot size={28} />
+          </div>
+          <p className="font-black tracking-tight text-foreground mb-2">You are now chatting with a random stranger.</p>
+          <p className="text-xs sm:text-sm text-muted-foreground max-w-sm leading-relaxed">
+            Say hi, ask what they are building, or use the icebreaker. Messages stay in this browser session only.
+          </p>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="flex-1 overflow-y-auto p-4 space-y-4">
+    <div className="flex-1 min-h-0 overflow-y-auto p-3 sm:p-5 space-y-4 bg-[radial-gradient(circle_at_top_right,hsl(var(--primary)/0.10),transparent_32%),radial-gradient(circle_at_bottom_left,hsl(var(--secondary)/0.45),transparent_30%)]">
       {messages.map((msg) => {
         if (msg.sender === "system") {
+          const tone = msg.tone || 'default';
+          const Icon = tone === 'danger' || tone === 'warning' ? TriangleAlert : ShieldCheck;
           return (
-            <div key={msg.id} className="flex justify-center">
-              <span className="bg-secondary/80 text-secondary-foreground text-xs px-3 py-1 rounded-[3px] font-bold">
-                {msg.text}
+            <div key={msg.id} className="flex justify-center px-2">
+              <span className={`inline-flex items-center gap-2 max-w-[92%] border text-[11px] sm:text-xs px-3 py-1.5 rounded-[3px] font-bold shadow-[2px_2px_0_hsl(var(--border))] ${systemToneClass[tone]}`}>
+                <Icon size={13} className="shrink-0" />
+                <span className="leading-relaxed">{msg.text}</span>
               </span>
             </div>
           );
@@ -34,19 +52,24 @@ export const MessageList = ({ messages, isStrangerTyping }: { messages: Message[
         const isMe = msg.sender === "me";
         return (
           <div key={msg.id} className={`flex flex-col ${isMe ? "items-end" : "items-start"}`}>
-            <div className="flex items-end gap-2 max-w-[85%]">
+            <div className="flex items-end gap-2 max-w-[88%] sm:max-w-[78%]">
+              {!isMe && (
+                <div className="hidden sm:flex w-7 h-7 rounded-[3px] gum-border bg-secondary items-center justify-center text-xs font-black shrink-0">
+                  ?
+                </div>
+              )}
               <div
-                className={`p-3 rounded-[3px] text-sm leading-relaxed whitespace-pre-wrap ${
+                className={`p-3 sm:p-3.5 rounded-[3px] text-sm leading-relaxed whitespace-pre-wrap break-words gum-border ${
                   isMe
-                    ? "bg-primary text-primary-foreground gum-border-dark shadow-[2px_2px_0px_#000]"
-                    : "bg-background gum-border text-foreground shadow-[2px_2px_0px_rgba(0,0,0,0.1)] dark:shadow-[2px_2px_0px_rgba(255,255,255,0.1)]"
+                    ? "bg-primary text-primary-foreground shadow-[3px_3px_0px_hsl(var(--border))]"
+                    : "bg-background text-foreground shadow-[3px_3px_0px_hsl(var(--border)/0.35)]"
                 }`}
               >
                 {msg.text}
               </div>
             </div>
             <span className="text-[10px] text-muted-foreground mt-1 mx-1 font-mono">
-              {format(msg.timestamp, "HH:mm")}
+              {isMe ? 'You' : 'Stranger'} · {format(msg.timestamp, "HH:mm")}
             </span>
           </div>
         );
@@ -54,7 +77,10 @@ export const MessageList = ({ messages, isStrangerTyping }: { messages: Message[
       {isStrangerTyping && (
         <div className="flex flex-col items-start animate-in fade-in slide-in-from-bottom-2 duration-300">
           <div className="flex items-end gap-2 max-w-[85%]">
-            <div className="bg-background gum-border text-foreground shadow-[2px_2px_0px_rgba(0,0,0,0.1)] dark:shadow-[2px_2px_0px_rgba(255,255,255,0.1)] p-3 rounded-[3px] text-sm leading-relaxed flex items-center gap-1.5 h-11 w-16 justify-center">
+            <div className="hidden sm:flex w-7 h-7 rounded-[3px] gum-border bg-secondary items-center justify-center text-xs font-black shrink-0">
+              ?
+            </div>
+            <div className="bg-background gum-border text-foreground shadow-[3px_3px_0px_hsl(var(--border)/0.35)] p-3 rounded-[3px] text-sm leading-relaxed flex items-center gap-1.5 h-11 w-16 justify-center">
               <span className="w-2 h-2 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '0ms' }} />
               <span className="w-2 h-2 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '150ms' }} />
               <span className="w-2 h-2 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '300ms' }} />
@@ -62,7 +88,6 @@ export const MessageList = ({ messages, isStrangerTyping }: { messages: Message[
           </div>
         </div>
       )}
-      
       <div ref={bottomRef} />
     </div>
   );

--- a/src/components/stranger/StrangerChat.tsx
+++ b/src/components/stranger/StrangerChat.tsx
@@ -1,133 +1,353 @@
-import { useState, useRef } from "react";
-import { useStrangerMatch } from "./useStrangerMatch";
-import { MessageList } from "./MessageList";
-import { Send, UserRoundX, Orbit } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
+import {
+  Ban,
+  Brush,
+  Eraser,
+  HeartHandshake,
+  Loader2,
+  MessageSquareText,
+  Radar,
+  RefreshCcw,
+  Send,
+  ShieldCheck,
+  Signal,
+  Sparkles,
+  Tags,
+  UserRoundX,
+  UsersRound,
+  Zap,
+} from "lucide-react";
 import { FrogLoader } from "@/components/ui/FrogLoader";
+import {
+  STRANGER_INTERESTS,
+  StrangerMatchMode,
+  StrangerSearchOptions,
+  useStrangerMatch,
+} from "./useStrangerMatch";
+import { MessageList } from "./MessageList";
+
+const connectionCopy: Record<string, { label: string; className: string }> = {
+  initialized: { label: "Warming up", className: "bg-yellow-500" },
+  connecting: { label: "Connecting", className: "bg-yellow-500 animate-pulse" },
+  connected: { label: "Realtime live", className: "bg-green-500 animate-pulse" },
+  disconnected: { label: "Reconnecting", className: "bg-yellow-500 animate-pulse" },
+  suspended: { label: "Unstable", className: "bg-orange-500 animate-pulse" },
+  failed: { label: "Offline", className: "bg-destructive" },
+  closed: { label: "Closed", className: "bg-muted-foreground" },
+};
+
+const interestLabel = (id: string) => STRANGER_INTERESTS.find((interest) => interest.id === id)?.label || id;
 
 export const StrangerChat = () => {
-  const { status, messages, sendMessage, startSearch, stopSearch, skip, strangerName, onlineCount, isStrangerTyping, sendTypingIndicator } = useStrangerMatch();
-  const [text, setText] = useState("");
-  const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const {
+    status,
+    messages,
+    sendMessage,
+    startSearch,
+    stopSearch,
+    skip,
+    reportAndSkip,
+    clearMessages,
+    strangerName,
+    onlineCount,
+    isStrangerTyping,
+    sendTypingIndicator,
+    connectionState,
+    searchHint,
+    peerInterests,
+    currentOptions,
+    blockedCount,
+    maxMessageLength,
+  } = useStrangerMatch();
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setText(e.target.value);
-    
-    if (status === 'matched') {
-       sendTypingIndicator(true);
-       if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
-       typingTimeoutRef.current = setTimeout(() => sendTypingIndicator(false), 2000);
+  const [text, setText] = useState("");
+  const [selectedInterests, setSelectedInterests] = useState<string[]>(["javascript", "react"]);
+  const [matchMode, setMatchMode] = useState<StrangerMatchMode>("shared");
+  const [composerNotice, setComposerNotice] = useState("");
+  const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const connection = connectionCopy[connectionState] || connectionCopy.initialized;
+  const selectedInterestNames = useMemo(() => selectedInterests.map(interestLabel).join(", "), [selectedInterests]);
+  const peerInterestNames = useMemo(() => peerInterests.map(interestLabel), [peerInterests]);
+
+  useEffect(() => {
+    return () => {
+      if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
+      sendTypingIndicator(false);
+    };
+  }, [sendTypingIndicator]);
+
+  const toggleInterest = (id: string) => {
+    setSelectedInterests((prev) => {
+      if (prev.includes(id)) return prev.filter((interest) => interest !== id);
+      if (prev.length >= 5) return prev;
+      return [...prev, id];
+    });
+  };
+
+  const beginSearch = () => {
+    const options: StrangerSearchOptions = {
+      interests: selectedInterests,
+      matchMode,
+    };
+    void startSearch(options);
+  };
+
+  const handleInputChange = (value: string) => {
+    const next = value.slice(0, maxMessageLength);
+    setText(next);
+
+    if (status === "matched") {
+      sendTypingIndicator(next.trim().length > 0);
+      if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
+      typingTimeoutRef.current = setTimeout(() => sendTypingIndicator(false), 1800);
     }
   };
 
   const handleSend = () => {
-    if (!text.trim() || status !== 'matched') return;
-    sendMessage(text.trim());
-    setText("");
-    
-    if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
-    sendTypingIndicator(false);
+    if (!text.trim() || status !== "matched") return;
+    const result = sendMessage(text);
+
+    if (result.ok) {
+      setText("");
+      setComposerNotice("");
+      if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
+      sendTypingIndicator(false);
+      return;
+    }
+
+    if (result.reason === "cooldown") {
+      setComposerNotice("Slow down a second — anti-spam guard is active.");
+      window.setTimeout(() => setComposerNotice(""), 1600);
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      handleSend();
+    }
   };
 
   return (
-    <div className="flex border-2 border-border flex-col flex-1 w-full bg-background gum-card overflow-hidden shadow-[4px_4px_0px_#000] dark:shadow-[4px_4px_0px_theme(colors.border)] mb-4 lg:mb-0">
-      {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b-2 border-border bg-secondary/30">
-        <div className="flex items-center gap-3">
-           <div className={`w-3 h-3 rounded-full border-2 border-background shadow-sm shrink-0 ${status === 'matched' ? 'bg-green-500 animate-pulse' : status === 'searching' ? 'bg-yellow-500 animate-pulse' : 'bg-red-500'}`} />
-           <div className="flex flex-col">
-               <h2 className="font-bold tracking-tighter truncate text-sm sm:text-base whitespace-nowrap overflow-hidden leading-tight">
-                  {status === 'idle' ? 'Stranger Lobby' : status === 'searching' ? 'Searching for a stranger...' : `Chatting with ${strangerName}`}
-               </h2>
-               {status === 'idle' && (
-                  <span className="text-[10px] text-muted-foreground font-bold tracking-tight">
-                     <span className="inline-block w-1.5 h-1.5 bg-green-500 rounded-full mr-1 animate-pulse"></span>
-                     {onlineCount} {onlineCount === 1 ? 'coder' : 'coders'} online now
-                  </span>
-               )}
-           </div>
+    <div className="flex border-2 border-border flex-col flex-1 w-full bg-background gum-card overflow-hidden shadow-[4px_4px_0px_hsl(var(--border))] mb-4 lg:mb-0">
+      <div className="flex flex-col gap-3 border-b-2 border-border bg-secondary/30 p-3 sm:p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className={`w-3.5 h-3.5 mt-1 rounded-full border-2 border-background shadow-sm shrink-0 ${status === 'matched' ? 'bg-green-500 animate-pulse' : status === 'searching' ? 'bg-yellow-500 animate-pulse' : 'bg-red-500'}`} />
+            <div className="min-w-0">
+              <h2 className="font-black tracking-tighter truncate text-sm sm:text-lg whitespace-nowrap overflow-hidden leading-tight">
+                {status === "idle" ? "Stranger Lobby" : status === "searching" ? "Searching the anonymous lobby" : `Chatting with ${strangerName}`}
+              </h2>
+              <div className="mt-1 flex flex-wrap items-center gap-2 text-[10px] sm:text-xs text-muted-foreground font-bold">
+                <span className="inline-flex items-center gap-1">
+                  <UsersRound size={13} /> {onlineCount} {onlineCount === 1 ? "coder" : "coders"} online
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  <span className={`w-2 h-2 rounded-full ${connection.className}`} /> {connection.label}
+                </span>
+                {blockedCount > 0 && <span className="inline-flex items-center gap-1"><Ban size={13} /> {blockedCount} avoided this session</span>}
+              </div>
+            </div>
+          </div>
+
+          {status !== "idle" && (
+            <button
+              onClick={() => void stopSearch()}
+              className="gum-btn shrink-0 bg-background text-destructive border-destructive/50 px-2.5 sm:px-3 py-1.5 text-[11px] sm:text-xs font-black hover:bg-destructive hover:text-destructive-foreground transition-colors"
+            >
+              Disconnect
+            </button>
+          )}
         </div>
-        
-        {status !== 'idle' && (
-           <button 
-             onClick={stopSearch}
-             className="text-xs font-bold text-destructive hover:underline"
-           >
-             Disconnect
-           </button>
-        )}
+
+        <div className="flex flex-wrap items-center gap-2 text-[10px] sm:text-xs font-bold text-muted-foreground">
+          <span className="inline-flex items-center gap-1 rounded-[3px] border border-border bg-background/70 px-2 py-1">
+            <ShieldCheck size={13} /> Text only
+          </span>
+          <span className="inline-flex items-center gap-1 rounded-[3px] border border-border bg-background/70 px-2 py-1">
+            <Zap size={13} /> Ephemeral
+          </span>
+          <span className="inline-flex items-center gap-1 rounded-[3px] border border-border bg-background/70 px-2 py-1">
+            <Signal size={13} /> Ably realtime
+          </span>
+          {status === "matched" && peerInterestNames.length > 0 && (
+            <span className="inline-flex items-center gap-1 rounded-[3px] border border-primary/50 bg-primary/10 text-foreground px-2 py-1">
+              <Tags size={13} /> Stranger likes {peerInterestNames.join(", ")}
+            </span>
+          )}
+        </div>
       </div>
 
-      {/* Body */}
-      {status === 'idle' && messages.length === 0 ? (
-        <div className="flex-1 flex flex-col items-center justify-center p-4 sm:p-8 space-y-4 sm:space-y-6 text-center overflow-y-auto min-h-0">
-            <div className="w-16 h-16 sm:w-20 sm:h-20 shrink-0 rounded-[3px] gum-border bg-primary/10 flex items-center justify-center text-primary shadow-[4px_4px_0px_#000] dark:shadow-[4px_4px_0px_theme(colors.primary.DEFAULT)]">
-               <Orbit size={32} className="sm:w-10 sm:h-10" />
-            </div>
-            <div>
-               <h3 className="text-xl sm:text-2xl font-bold tracking-tight mb-2 sm:mb-3">Talk to Strangers</h3>
-               <p className="text-xs sm:text-sm text-muted-foreground leading-relaxed max-w-sm mx-auto">
-                  You will be instantly matched with another random developer. Chats are completely anonymous, ephemeral, and vanish instantly when you disconnect.
-               </p>
-            </div>
-            <button
-               onClick={startSearch}
-               className="gum-btn block shrink-0 bg-primary text-primary-foreground font-extrabold px-6 py-2.5 sm:px-8 sm:py-3.5 w-full max-w-[200px] sm:max-w-xs transition-transform hover:translate-x-1 hover:-translate-y-1 shadow-[4px_4px_0px_theme(colors.primary.DEFAULT)]"
-            >
-               Start Searching
-            </button>
+      {status === "idle" && messages.length === 0 ? (
+        <div className="flex-1 min-h-0 overflow-y-auto bg-[radial-gradient(circle_at_top_left,hsl(var(--primary)/0.16),transparent_28%),radial-gradient(circle_at_bottom_right,hsl(var(--secondary)/0.65),transparent_28%)] p-3 sm:p-5">
+          <div className="grid h-full min-h-[560px] gap-4 lg:grid-cols-[1.05fr_0.95fr]">
+            <section className="flex flex-col justify-center rounded-[3px] gum-border bg-background/85 p-5 sm:p-7 shadow-[4px_4px_0_hsl(var(--border))]">
+              <div className="inline-flex w-fit items-center gap-2 rounded-[3px] gum-border bg-primary/10 px-3 py-1.5 text-xs font-black text-primary mb-5">
+                <Sparkles size={14} /> Anonymous dev roulette
+              </div>
+              <h3 className="text-2xl sm:text-4xl font-black tracking-tighter leading-tight mb-3">
+                Meet a random stranger. Keep it text. Keep it weirdly useful.
+              </h3>
+              <p className="text-sm text-muted-foreground leading-relaxed max-w-xl mb-6">
+                Pick interests, choose how strict matching should be, then jump into an ephemeral Ably-powered chat. No profile, no camera, no Supabase chat history.
+              </p>
+
+              <div className="grid gap-3 sm:grid-cols-3 mb-6">
+                {[
+                  { icon: ShieldCheck, title: "Anonymous", copy: "Your Genjutsu profile is not shared." },
+                  { icon: MessageSquareText, title: "Text only", copy: "No audio, files, video, or camera." },
+                  { icon: RefreshCcw, title: "Skip fast", copy: "Avoid and rematch in this session." },
+                ].map((item) => (
+                  <div key={item.title} className="rounded-[3px] gum-border bg-secondary/30 p-3 text-left">
+                    <item.icon size={18} className="mb-2 text-primary" />
+                    <p className="text-xs font-black uppercase tracking-tight">{item.title}</p>
+                    <p className="text-[11px] text-muted-foreground leading-relaxed mt-1">{item.copy}</p>
+                  </div>
+                ))}
+              </div>
+
+              <button
+                onClick={beginSearch}
+                disabled={connectionState === "failed" || connectionState === "closed"}
+                className="gum-btn group w-full sm:w-fit bg-primary text-primary-foreground font-black px-6 py-3.5 rounded-[3px] shadow-[4px_4px_0px_hsl(var(--border))] disabled:opacity-50 disabled:cursor-not-allowed hover:-translate-y-0.5 hover:translate-x-0.5 transition-transform"
+              >
+                <span className="inline-flex items-center gap-2">
+                  <Radar size={18} className="group-hover:animate-spin" /> Start Searching
+                </span>
+              </button>
+            </section>
+
+            <aside className="rounded-[3px] gum-border bg-background/90 p-4 sm:p-5 shadow-[4px_4px_0_hsl(var(--border))] flex flex-col gap-4">
+              <div>
+                <div className="flex items-center justify-between gap-2 mb-3">
+                  <div>
+                    <h3 className="font-black tracking-tight flex items-center gap-2"><Tags size={18} /> Interests</h3>
+                    <p className="text-[11px] text-muted-foreground font-bold">Pick up to 5. Shared mode prefers overlap.</p>
+                  </div>
+                  <span className="text-[10px] font-black rounded-[3px] gum-border bg-secondary px-2 py-1">{selectedInterests.length}/5</span>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {STRANGER_INTERESTS.map((interest) => {
+                    const active = selectedInterests.includes(interest.id);
+                    return (
+                      <button
+                        key={interest.id}
+                        onClick={() => toggleInterest(interest.id)}
+                        aria-pressed={active}
+                        className={`rounded-[3px] border-2 px-2.5 py-1.5 text-xs font-black transition-all ${active ? "border-primary bg-primary text-primary-foreground shadow-[2px_2px_0_hsl(var(--border))]" : "border-border bg-secondary/40 text-foreground hover:bg-secondary"}`}
+                      >
+                        <span className="mr-1">{interest.emoji}</span>{interest.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="rounded-[3px] gum-border bg-secondary/20 p-3">
+                <h3 className="font-black tracking-tight flex items-center gap-2 mb-3"><HeartHandshake size={18} /> Match mode</h3>
+                <div className="grid grid-cols-2 gap-2">
+                  {([
+                    { id: "shared", label: "Shared", copy: "Prefer same tags" },
+                    { id: "random", label: "Random", copy: "Anyone online" },
+                  ] as { id: StrangerMatchMode; label: string; copy: string }[]).map((mode) => (
+                    <button
+                      key={mode.id}
+                      onClick={() => setMatchMode(mode.id)}
+                      aria-pressed={matchMode === mode.id}
+                      className={`rounded-[3px] gum-border p-3 text-left transition-all ${matchMode === mode.id ? "bg-primary text-primary-foreground shadow-[3px_3px_0_hsl(var(--border))]" : "bg-background hover:bg-secondary"}`}
+                    >
+                      <span className="block text-sm font-black">{mode.label}</span>
+                      <span className="block text-[10px] font-bold opacity-75 mt-1">{mode.copy}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="rounded-[3px] gum-border bg-muted/40 p-3 text-xs text-muted-foreground leading-relaxed">
+                <p className="font-black text-foreground mb-1 flex items-center gap-2"><Brush size={15} /> Current setup</p>
+                <p>{matchMode === "shared" ? "Shared-interest first" : "Random-first"} matching{selectedInterests.length ? ` with ${selectedInterestNames}.` : " with no selected tags."}</p>
+              </div>
+            </aside>
+          </div>
         </div>
       ) : (
-        <div className="flex-1 flex flex-col h-full bg-secondary/5">
-            {status === 'searching' ? (
-               <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground">
-                  <FrogLoader size={48} className="mb-4 opacity-50" />
-                  <p className="font-bold tracking-widest uppercase text-xs">Waiting in lobby...</p>
-               </div>
-            ) : (
-               <MessageList messages={messages} isStrangerTyping={isStrangerTyping} />
-            )}
-            
-            {/* Input Area */}
-            {status === 'idle' && messages.length > 0 ? (
-               <div className="p-4 bg-background border-t-2 border-border flex justify-center">
-                   <button 
-                     onClick={startSearch}
-                     className="gum-btn w-full sm:w-auto bg-primary text-primary-foreground hover:scale-105 active:scale-95 transition-transform font-bold px-8 py-3 rounded-[3px] shadow-[4px_4px_0px_theme(colors.primary.DEFAULT)] dark:shadow-[4px_4px_0px_#000]"
-                   >
-                     Find a new Stranger
-                   </button>
-               </div>
-            ) : (
-               <div className={`p-4 bg-background border-t-2 border-border ${status !== 'matched' ? 'opacity-50 pointer-events-none' : ''}`}>
-                  <div className="flex gap-1.5 sm:gap-2 relative">
-                      <button 
-                        onClick={skip}
-                        className="flex shrink-0 items-center justify-center gap-1 bg-destructive text-destructive-foreground px-3 sm:px-4 py-2 rounded-[3px] font-bold text-sm gum-btn hover:bg-red-600 transition-colors"
-                      >
-                       <UserRoundX size={16} />
-                       <span className="hidden sm:inline">Skip</span>
-                     </button>
+        <div className="flex-1 min-h-0 flex flex-col bg-secondary/5">
+          {status === "searching" ? (
+            <div className="flex-1 min-h-0 flex flex-col items-center justify-center text-center p-6 bg-[radial-gradient(circle,hsl(var(--primary)/0.16),transparent_35%)]">
+              <div className="relative mb-6">
+                <FrogLoader size={56} className="opacity-80" />
+                <Loader2 size={92} className="absolute -inset-4 text-primary/20 animate-spin" />
+              </div>
+              <p className="font-black tracking-widest uppercase text-xs text-primary mb-2">Waiting in lobby...</p>
+              <h3 className="text-xl sm:text-2xl font-black tracking-tight mb-2">{searchHint}</h3>
+              <p className="text-xs sm:text-sm text-muted-foreground max-w-md leading-relaxed">
+                Mode: <span className="font-black text-foreground">{currentOptions.matchMode === "shared" ? "Shared interests" : "Random"}</span>
+                {currentOptions.interests.length > 0 && <> · Tags: <span className="font-black text-foreground">{currentOptions.interests.map(interestLabel).join(", ")}</span></>}
+              </p>
+              <button onClick={() => void stopSearch("Search cancelled.")} className="gum-btn mt-6 bg-background px-5 py-2 text-xs font-black">
+                Cancel search
+              </button>
+            </div>
+          ) : (
+            <MessageList messages={messages} isStrangerTyping={isStrangerTyping} />
+          )}
 
-                     <input
-                       type="text"
-                       value={text}
-                       onChange={handleInputChange}
-                       onKeyDown={(e) => e.key === 'Enter' && handleSend()}
-                       placeholder="Type a message..."
-                       className="flex-1 min-w-0 bg-background border-2 border-border rounded-[3px] px-2 sm:px-4 py-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-primary/20 placeholder:text-muted-foreground/50 transition-all font-mono"
-                       disabled={status !== 'matched'}
-                     />
-                     
-                     <button 
-                       onClick={handleSend}
-                       disabled={status !== 'matched' || !text.trim()}
-                       className="bg-primary shrink-0 text-primary-foreground p-2 px-3 sm:px-6 rounded-[3px] gum-btn disabled:opacity-50 disabled:cursor-not-allowed hover:scale-105 active:scale-95 transition-transform"
-                     >
-                       <Send size={18} />
-                     </button>
+          {status === "idle" && messages.length > 0 ? (
+            <div className="p-3 sm:p-4 bg-background border-t-2 border-border flex flex-col sm:flex-row gap-2 sm:items-center sm:justify-between">
+              <p className="text-xs text-muted-foreground font-bold">Session ended. Start a fresh anonymous chat when you are ready.</p>
+              <button
+                onClick={beginSearch}
+                className="gum-btn bg-primary text-primary-foreground hover:scale-[1.02] active:scale-95 transition-transform font-black px-5 py-2.5 rounded-[3px] shadow-[3px_3px_0_hsl(var(--border))]"
+              >
+                Find a new Stranger
+              </button>
+            </div>
+          ) : (
+            <div className={`bg-background border-t-2 border-border ${status !== "matched" ? "opacity-50 pointer-events-none" : ""}`}>
+              {status === "matched" && (
+                <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border/60 px-3 sm:px-4 py-2 text-[10px] sm:text-xs font-bold text-muted-foreground">
+                  <span>Enter sends · Shift+Enter adds a line · {text.length}/{maxMessageLength}</span>
+                  <div className="flex items-center gap-2">
+                    <button onClick={clearMessages} className="inline-flex items-center gap-1 hover:text-foreground"><Eraser size={13} /> Clear local</button>
+                    <button onClick={() => void reportAndSkip()} className="inline-flex items-center gap-1 hover:text-destructive"><Ban size={13} /> Safety skip</button>
                   </div>
-               </div>
-            )}
+                </div>
+              )}
+              <div className="p-3 sm:p-4">
+                {composerNotice && <p className="mb-2 text-[11px] font-bold text-destructive">{composerNotice}</p>}
+                <div className="flex gap-2 relative items-end">
+                  <button
+                    onClick={() => void skip()}
+                    className="flex shrink-0 items-center justify-center gap-1 bg-destructive text-destructive-foreground px-3 sm:px-4 py-3 rounded-[3px] font-black text-sm gum-btn hover:bg-red-600 transition-colors"
+                  >
+                    <UserRoundX size={16} />
+                    <span className="hidden sm:inline">Skip</span>
+                  </button>
+
+                  <textarea
+                    value={text}
+                    onChange={(e) => handleInputChange(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    placeholder="Type a message..."
+                    rows={1}
+                    className="flex-1 min-h-[46px] max-h-32 min-w-0 bg-background border-2 border-border rounded-[3px] px-3 sm:px-4 py-3 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-primary/20 placeholder:text-muted-foreground/50 transition-all font-mono resize-none"
+                    disabled={status !== "matched"}
+                  />
+
+                  <button
+                    onClick={handleSend}
+                    disabled={status !== "matched" || !text.trim()}
+                    className="bg-primary shrink-0 text-primary-foreground p-3 px-3 sm:px-5 rounded-[3px] gum-btn disabled:opacity-50 disabled:cursor-not-allowed hover:scale-105 active:scale-95 transition-transform"
+                    aria-label="Send message"
+                  >
+                    <Send size={18} />
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/stranger/useStrangerMatch.tsx
+++ b/src/components/stranger/useStrangerMatch.tsx
@@ -7,77 +7,419 @@ export interface Message {
   text: string;
   sender: 'me' | 'stranger' | 'system';
   timestamp: number;
+  tone?: 'default' | 'success' | 'warning' | 'danger';
 }
 
+export type StrangerStatus = 'idle' | 'searching' | 'matched';
+export type StrangerMatchMode = 'random' | 'shared';
+export type StrangerConnectionState = 'initialized' | 'connecting' | 'connected' | 'disconnected' | 'suspended' | 'failed' | 'closed';
+
+export interface StrangerInterest {
+  id: string;
+  label: string;
+  emoji: string;
+}
+
+export interface StrangerSearchOptions {
+  interests: string[];
+  matchMode: StrangerMatchMode;
+}
+
+interface LobbyPresenceData extends StrangerSearchOptions {
+  searching: boolean;
+  startedAt: number;
+  searchId: string;
+  version: number;
+}
+
+interface OfferPayload {
+  target: string;
+  targetSearchId: string;
+  fromClientId: string;
+  channel: string;
+  matchId: string;
+  interests: string[];
+  matchMode: StrangerMatchMode;
+  offeredAt: number;
+}
+
+const STORAGE_KEY = 'genjutsu_stranger_id';
+const LOBBY_CHANNEL = 'genjutsu_stranger_lobby';
+const GLOBAL_CHANNEL = 'genjutsu_stranger_global';
+const MAX_MESSAGE_LENGTH = 600;
+const MIN_MESSAGE_INTERVAL_MS = 850;
+const SHARED_MATCH_FALLBACK_MS = 8000;
+const IDLE_TIMEOUT_MS = 3 * 60 * 1000;
+
+const BLOCKED_WORDS = ['slur', 'doxx', 'kys'];
+
+export const STRANGER_INTERESTS: StrangerInterest[] = [
+  { id: 'javascript', label: 'JavaScript', emoji: '🟨' },
+  { id: 'react', label: 'React', emoji: '⚛️' },
+  { id: 'ai', label: 'AI', emoji: '🤖' },
+  { id: 'rust', label: 'Rust', emoji: '🦀' },
+  { id: 'design', label: 'Design', emoji: '🎨' },
+  { id: 'gaming', label: 'Gaming', emoji: '🎮' },
+  { id: 'anime', label: 'Anime', emoji: '🌸' },
+  { id: 'startup', label: 'Startup', emoji: '🚀' },
+  { id: 'debugging', label: 'Debugging', emoji: '🐛' },
+  { id: 'open-source', label: 'Open Source', emoji: '🌐' },
+];
+
+export const CONVERSATION_STARTERS = [
+  'Ask what they are building right now.',
+  'Tabs or spaces, and why is their answer dangerous?',
+  'What bug wasted their week?',
+  'Favorite language for a weekend project?',
+  'What tool could they not live without?',
+  'Ask for one underrated dev tip.',
+  'What would they ship if they had 48 free hours?',
+  'Ask about their current side quest.',
+];
+
+const createId = (prefix: string) => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return `${prefix}_${crypto.randomUUID()}`;
+  }
+
+  return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+};
+
+const normalizeInterests = (interests: string[]) => {
+  const allowed = new Set(STRANGER_INTERESTS.map((interest) => interest.id));
+  return Array.from(new Set(interests.filter((interest) => allowed.has(interest)))).slice(0, 5);
+};
+
+const getSharedInterests = (a: string[], b: string[]) => a.filter((interest) => b.includes(interest));
+
+const sanitizeMessage = (text: string) => {
+  let cleaned = Array.from(text.replace(/\r\n?/g, '\n')).filter((char) => {
+    const code = char.charCodeAt(0);
+    return char === '\n' || (code > 31 && code !== 127);
+  }).join('').replace(/\n{3,}/g, '\n\n').trim();
+  BLOCKED_WORDS.forEach((word) => {
+    cleaned = cleaned.replace(new RegExp(`\\b${word}\\b`, 'gi'), '***');
+  });
+  return cleaned.slice(0, MAX_MESSAGE_LENGTH);
+};
+
+const getRandomStarter = () => CONVERSATION_STARTERS[Math.floor(Math.random() * CONVERSATION_STARTERS.length)];
+
+const getOrCreateClientId = () => {
+  const generatedId = `user_${Math.random().toString(36).substring(2, 12)}`;
+
+  try {
+    const storedId = localStorage.getItem(STORAGE_KEY);
+    if (storedId) return storedId;
+
+    localStorage.setItem(STORAGE_KEY, generatedId);
+  } catch (e) {
+    // Private browsing or locked-down webviews can block localStorage.
+  }
+
+  return generatedId;
+};
+
 export function useStrangerMatch() {
-  const [status, setStatus] = useState<'idle' | 'searching' | 'matched'>('idle');
+  const [status, setStatus] = useState<StrangerStatus>('idle');
   const [messages, setMessages] = useState<Message[]>([]);
   const [strangerName, setStrangerName] = useState<string>('Stranger');
   const [onlineCount, setOnlineCount] = useState<number>(1);
   const [isStrangerTyping, setIsStrangerTyping] = useState<boolean>(false);
-  
+  const [connectionState, setConnectionState] = useState<StrangerConnectionState>('initialized');
+  const [searchHint, setSearchHint] = useState('Ready for anonymous text chat.');
+  const [peerInterests, setPeerInterests] = useState<string[]>([]);
+  const [currentOptions, setCurrentOptions] = useState<StrangerSearchOptions>({ interests: [], matchMode: 'random' });
+  const [blockedCount, setBlockedCount] = useState(0);
+
   const ablyRef = useRef<Ably.Realtime | null>(null);
+  const globalChannelRef = useRef<Ably.RealtimeChannel | null>(null);
   const lobbyChannelRef = useRef<Ably.RealtimeChannel | null>(null);
   const chatChannelRef = useRef<Ably.RealtimeChannel | null>(null);
-  
+
   const mountedRef = useRef<boolean>(true);
+  const statusRef = useRef<StrangerStatus>('idle');
   const isActionPending = useRef<boolean>(false);
   const alreadyMatchedRef = useRef<boolean>(false);
+  const searchIdRef = useRef<string>('');
+  const optionsRef = useRef<StrangerSearchOptions>({ interests: [], matchMode: 'random' });
+  const blockedPeersRef = useRef<Set<string>>(new Set());
+  const currentPeerIdRef = useRef<string | null>(null);
+  const lastMessageAtRef = useRef<number>(0);
+  const fallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fallbackWidenedRef = useRef(false);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const STORAGE_KEY = 'genjutsu_stranger_id';
-
-  // Safe setState wrappers — prevents "Should have a queue" React error
-  // by guarding against state updates after unmount
-  const safeSetStatus = useCallback((v: 'idle' | 'searching' | 'matched') => { if (mountedRef.current) setStatus(v); }, []);
+  const safeSetStatus = useCallback((v: StrangerStatus) => {
+    statusRef.current = v;
+    if (mountedRef.current) setStatus(v);
+  }, []);
   const safeSetMessages = useCallback((v: Message[] | ((prev: Message[]) => Message[])) => { if (mountedRef.current) setMessages(v); }, []);
   const safeSetStrangerName = useCallback((v: string) => { if (mountedRef.current) setStrangerName(v); }, []);
   const safeSetOnlineCount = useCallback((v: number) => { if (mountedRef.current) setOnlineCount(v); }, []);
   const safeSetIsStrangerTyping = useCallback((v: boolean) => { if (mountedRef.current) setIsStrangerTyping(v); }, []);
+  const safeSetConnectionState = useCallback((v: StrangerConnectionState) => { if (mountedRef.current) setConnectionState(v); }, []);
+  const safeSetSearchHint = useCallback((v: string) => { if (mountedRef.current) setSearchHint(v); }, []);
+  const safeSetPeerInterests = useCallback((v: string[]) => { if (mountedRef.current) setPeerInterests(v); }, []);
+  const safeSetCurrentOptions = useCallback((v: StrangerSearchOptions) => { if (mountedRef.current) setCurrentOptions(v); }, []);
+  const safeSetBlockedCount = useCallback((v: number) => { if (mountedRef.current) setBlockedCount(v); }, []);
+
+  const addSystemMessage = useCallback((text: string, tone: Message['tone'] = 'default') => {
+    safeSetMessages((prev) => [...prev, { id: createId('sys'), text, sender: 'system', timestamp: Date.now(), tone }]);
+  }, [safeSetMessages]);
+
+  const clearFallbackTimer = useCallback(() => {
+    if (fallbackTimerRef.current) {
+      clearTimeout(fallbackTimerRef.current);
+      fallbackTimerRef.current = null;
+    }
+  }, []);
+
+  const clearIdleTimer = useCallback(() => {
+    if (idleTimerRef.current) {
+      clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = null;
+    }
+  }, []);
+
+  const cleanupLobby = useCallback(async () => {
+    const lobby = lobbyChannelRef.current;
+    lobbyChannelRef.current = null;
+    clearFallbackTimer();
+
+    if (!lobby) return;
+
+    lobby.unsubscribe();
+    lobby.presence.unsubscribe();
+    await lobby.presence.leave().catch(() => {});
+    await lobby.detach().catch(() => {});
+  }, [clearFallbackTimer]);
+
+  const cleanupChat = useCallback(async () => {
+    const chat = chatChannelRef.current;
+    chatChannelRef.current = null;
+    clearIdleTimer();
+    safeSetIsStrangerTyping(false);
+
+    if (!chat) return;
+
+    chat.unsubscribe();
+    chat.presence.unsubscribe();
+    await chat.presence.leave().catch(() => {});
+    await chat.detach().catch(() => {});
+  }, [clearIdleTimer, safeSetIsStrangerTyping]);
+
+  const resetIdleTimer = useCallback(() => {
+    clearIdleTimer();
+    if (statusRef.current !== 'matched') return;
+
+    idleTimerRef.current = setTimeout(() => {
+      addSystemMessage('Idle timeout reached. You were disconnected to keep the lobby fresh.', 'warning');
+      void cleanupChat().then(() => {
+        currentPeerIdRef.current = null;
+        safeSetStatus('idle');
+      });
+    }, IDLE_TIMEOUT_MS);
+  }, [addSystemMessage, cleanupChat, clearIdleTimer, safeSetStatus]);
+
+  const chooseCandidate = useCallback((presenceSet: any[], allowRandomFallback: boolean) => {
+    const ably = ablyRef.current;
+    if (!ably) return null;
+
+    const myOptions = optionsRef.current;
+    const candidates = presenceSet.filter((member) => {
+      const data = member.data as LobbyPresenceData | undefined;
+      if (!data?.searching || !data.searchId) return false;
+      if (member.clientId === ably.auth.clientId) return false;
+      if (blockedPeersRef.current.has(member.clientId)) return false;
+      if (data.searchId === searchIdRef.current) return false;
+      return true;
+    });
+
+    if (candidates.length === 0) return null;
+
+    const scored = candidates.map((member) => {
+      const data = member.data as LobbyPresenceData;
+      const shared = getSharedInterests(myOptions.interests, data.interests || []);
+      const wantsShared = myOptions.matchMode === 'shared' || data.matchMode === 'shared';
+      const eligible = !wantsShared || shared.length > 0 || allowRandomFallback;
+      return {
+        member,
+        data,
+        shared,
+        eligible,
+        score: shared.length * 1000 - (Date.now() - (data.startedAt || Date.now())) / 1000,
+      };
+    }).filter((candidate) => candidate.eligible);
+
+    if (scored.length === 0) return null;
+
+    scored.sort((a, b) => b.score - a.score);
+    const sharedCandidates = scored.filter((candidate) => candidate.shared.length > 0);
+    const pool = sharedCandidates.length > 0 ? sharedCandidates : scored;
+    return pool[Math.floor(Math.random() * Math.min(pool.length, 3))];
+  }, []);
+
+  const joinChat = useCallback(async (channelId: string, peerId: string, interests: string[] = []) => {
+    isActionPending.current = true;
+    clearFallbackTimer();
+    await cleanupLobby();
+
+    safeSetStatus('matched');
+    safeSetStrangerName('Stranger');
+    safeSetPeerInterests(normalizeInterests(interests));
+    safeSetSearchHint('Matched. Keep it text-only and be cool.');
+    currentPeerIdRef.current = peerId;
+
+    const ably = ablyRef.current;
+    if (!ably) {
+      safeSetStatus('idle');
+      isActionPending.current = false;
+      return;
+    }
+
+    try {
+      await cleanupChat();
+      const chatChannel = ably.channels.get(channelId);
+      chatChannelRef.current = chatChannel;
+
+      chatChannel.presence.subscribe('leave', (member) => {
+        if (member.clientId !== ably.auth.clientId) {
+          currentPeerIdRef.current = null;
+          safeSetStatus('idle');
+          safeSetIsStrangerTyping(false);
+          addSystemMessage('Stranger has disconnected.', 'warning');
+          void cleanupChat();
+        }
+      });
+
+      chatChannel.subscribe('message', (msg) => {
+        if (msg.connectionId !== ably.connection.id) {
+          const cleaned = sanitizeMessage(msg.data?.text || '');
+          if (!cleaned) return;
+
+          safeSetMessages((prev) => [...prev, {
+            id: msg.id || createId('msg'),
+            text: cleaned,
+            sender: 'stranger',
+            timestamp: msg.timestamp || Date.now(),
+          }]);
+          safeSetIsStrangerTyping(false);
+          resetIdleTimer();
+        }
+      });
+
+      chatChannel.subscribe('typing', (msg) => {
+        if (msg.connectionId !== ably.connection.id) {
+          safeSetIsStrangerTyping(!!msg.data?.isTyping);
+        }
+      });
+
+      await chatChannel.presence.enter({ interests: optionsRef.current.interests });
+      const shared = getSharedInterests(optionsRef.current.interests, interests);
+      addSystemMessage(
+        shared.length > 0
+          ? `Stranger found through ${shared.map((id) => STRANGER_INTERESTS.find((interest) => interest.id === id)?.label || id).join(', ')}.`
+          : 'Stranger found. Say hi.',
+        'success'
+      );
+      addSystemMessage(`Icebreaker: ${getRandomStarter()}`);
+      resetIdleTimer();
+    } catch (e: any) {
+      console.warn('Chat session error:', e.message);
+      safeSetStatus('idle');
+      addSystemMessage('Chat session failed. Try searching again.', 'danger');
+    } finally {
+      isActionPending.current = false;
+    }
+  }, [addSystemMessage, cleanupChat, cleanupLobby, clearFallbackTimer, resetIdleTimer, safeSetIsStrangerTyping, safeSetMessages, safeSetPeerInterests, safeSetSearchHint, safeSetStatus, safeSetStrangerName]);
+
+  const attemptMatch = useCallback(async (allowRandomFallback = false) => {
+    const ably = ablyRef.current;
+    const lobby = lobbyChannelRef.current;
+    if (!ably || !lobby || alreadyMatchedRef.current || statusRef.current !== 'searching') return;
+
+    try {
+      const presenceSet = await lobby.presence.get();
+      const candidate = chooseCandidate(presenceSet, allowRandomFallback);
+
+      if (!candidate) {
+        safeSetSearchHint(
+          optionsRef.current.matchMode === 'shared' && !allowRandomFallback
+            ? 'Looking for shared interests. We will widen the search shortly.'
+            : 'Waiting for another anonymous coder...'
+        );
+        return;
+      }
+
+      alreadyMatchedRef.current = true;
+      const matchId = createId('match');
+      const channel = `genjutsu_stranger_chat_${matchId}`;
+      const payload: OfferPayload = {
+        target: candidate.member.clientId,
+        targetSearchId: candidate.data.searchId,
+        fromClientId: ably.auth.clientId,
+        channel,
+        matchId,
+        interests: optionsRef.current.interests,
+        matchMode: optionsRef.current.matchMode,
+        offeredAt: Date.now(),
+      };
+
+      await lobby.publish('offer', payload);
+      await joinChat(channel, candidate.member.clientId, candidate.data.interests || []);
+    } catch (e: any) {
+      console.warn('Match attempt failed:', e.message);
+      safeSetSearchHint('Matchmaking hiccup. Still listening...');
+    }
+  }, [chooseCandidate, joinChat, safeSetSearchHint]);
 
   useEffect(() => {
     mountedRef.current = true;
-    // getConfig() is safely called inside useEffect — config is guaranteed
     const config = getConfig();
-    
-    // Initialize Ably with persistent clientId
-    let clientId = localStorage.getItem(STORAGE_KEY);
-    if (!clientId) {
-        clientId = "user_" + Math.random().toString(36).substring(2, 12);
-        localStorage.setItem(STORAGE_KEY, clientId);
-    }
+
+    const clientId = getOrCreateClientId();
 
     const clientOptions: any = { clientId };
 
     if (import.meta.env.DEV) {
-        const ABLY_KEY = config.VITE_ABLY_KEY;
-        if (!ABLY_KEY) {
-           console.error("VITE_ABLY_KEY is missing in local .env.");
-           safeSetMessages([{ id: 'error', text: 'Configuration error: Connection failed.', sender: 'system', timestamp: Date.now() }]);
-           return;
-        }
-        clientOptions.key = ABLY_KEY;
+      const ABLY_KEY = config.VITE_ABLY_KEY;
+      if (!ABLY_KEY) {
+        console.error('VITE_ABLY_KEY is missing in local .env.');
+        safeSetConnectionState('failed');
+        safeSetMessages([{ id: 'error', text: 'Configuration error: realtime connection failed.', sender: 'system', timestamp: Date.now(), tone: 'danger' }]);
+        return;
+      }
+      clientOptions.key = ABLY_KEY;
     } else {
-        const workerUrlPattern = import.meta.env.VITE_CONFIG_WORKER_URL || "https://genjutsu-config.workers.dev/config";
-        const base = new URL(workerUrlPattern);
-        base.pathname = "/ably-auth";
-        base.searchParams.set("clientId", clientId);
-        clientOptions.authUrl = base.toString();
+      const workerUrlPattern = import.meta.env.VITE_CONFIG_WORKER_URL || 'https://genjutsu-config.workers.dev/config';
+      const base = new URL(workerUrlPattern);
+      base.pathname = '/ably-auth';
+      base.searchParams.set('clientId', clientId);
+      clientOptions.authUrl = base.toString();
     }
 
     const client = new Ably.Realtime(clientOptions);
     ablyRef.current = client;
 
-    // Join global channel just to track active users on the page
-    const globalChannel = client.channels.get('genjutsu_stranger_global');
-    globalChannel.presence.enter().catch(() => {});
-    
+    client.connection.on((stateChange) => {
+      safeSetConnectionState(stateChange.current as StrangerConnectionState);
+      if (stateChange.current === 'failed' || stateChange.current === 'suspended') {
+        safeSetSearchHint('Realtime connection is unstable. Messages may pause.');
+      }
+    });
+
+    const globalChannel = client.channels.get(GLOBAL_CHANNEL);
+    globalChannelRef.current = globalChannel;
+    globalChannel.presence.enter({ page: 'stranger', at: Date.now() }).catch(() => {});
+
     const updateCount = async () => {
-        try {
-            const presence = await globalChannel.presence.get();
-            safeSetOnlineCount(Math.max(1, presence.length));
-        } catch (e) {
-            /* ignore error */
-        }
+      try {
+        const presence = await globalChannel.presence.get();
+        safeSetOnlineCount(Math.max(1, presence.length));
+      } catch (e) {
+        /* ignore presence count issues */
+      }
     };
 
     globalChannel.presence.subscribe(['enter', 'leave'], updateCount);
@@ -85,190 +427,187 @@ export function useStrangerMatch() {
 
     return () => {
       mountedRef.current = false;
+      void cleanupLobby();
+      void cleanupChat();
       try {
         globalChannel.presence.leave().catch(() => {});
         globalChannel.presence.unsubscribe();
+        client.connection.off();
         client.close();
       } catch (e) {
-        // Silently handle — connection may already be dead on slow networks
+        /* connection may already be gone */
       }
     };
-  }, [safeSetMessages, safeSetOnlineCount]);
+  }, [cleanupChat, cleanupLobby, safeSetConnectionState, safeSetMessages, safeSetOnlineCount, safeSetSearchHint]);
 
-  const startSearch = async () => {
+  useEffect(() => {
+    if (status === 'matched') resetIdleTimer();
+    return () => clearIdleTimer();
+  }, [clearIdleTimer, resetIdleTimer, status]);
+
+  const startSearch = useCallback(async (options: StrangerSearchOptions = { interests: [], matchMode: 'random' }) => {
     if (!ablyRef.current || isActionPending.current) return;
-    
+
     isActionPending.current = true;
     alreadyMatchedRef.current = false;
-    
+    fallbackWidenedRef.current = false;
+    searchIdRef.current = createId('search');
+
+    const normalizedOptions = {
+      interests: normalizeInterests(options.interests),
+      matchMode: options.matchMode,
+    };
+    optionsRef.current = normalizedOptions;
+
+    safeSetCurrentOptions(normalizedOptions);
     safeSetStatus('searching');
     safeSetMessages([]);
     safeSetStrangerName('Stranger');
     safeSetIsStrangerTyping(false);
-    
+    safeSetPeerInterests([]);
+    safeSetSearchHint(normalizedOptions.matchMode === 'shared' ? 'Scanning for shared interests...' : 'Looking for a random stranger...');
+
     const ably = ablyRef.current;
-    
+
     try {
-        // Fully clean up any previous chat channel
-        if (chatChannelRef.current) {
-           const prevChat = chatChannelRef.current;
-           chatChannelRef.current = null;
-           prevChat.unsubscribe();
-           prevChat.presence.unsubscribe();
-           await prevChat.presence.leave().catch(() => {});
-           try { prevChat.detach(); } catch(e) { /* ignore error */ }
-        }
+      await cleanupChat();
+      await cleanupLobby();
 
-        const lobby = ably.channels.get('genjutsu_stranger_lobby');
-        lobbyChannelRef.current = lobby;
+      const lobby = ably.channels.get(LOBBY_CHANNEL);
+      lobbyChannelRef.current = lobby;
+      lobby.unsubscribe();
 
-        // Clear previous subscriptions
-        lobby.unsubscribe();
+      lobby.subscribe('offer', (msg) => {
+        const data = msg.data as OfferPayload;
+        if (alreadyMatchedRef.current) return;
+        if (data.target !== ably.auth.clientId) return;
+        if (data.targetSearchId !== searchIdRef.current) return;
+        if (blockedPeersRef.current.has(data.fromClientId)) return;
 
-        // Listen for incoming match offers
-        lobby.subscribe('offer', (msg) => {
-           if (alreadyMatchedRef.current) return;
-           if (msg.data.target === ably.auth.clientId) {
-              alreadyMatchedRef.current = true;
-              lobby.unsubscribe();
-              lobby.presence.leave().catch(() => {});
-              joinChat(msg.data.channel, 'Stranger');
-           }
-        });
+        alreadyMatchedRef.current = true;
+        void joinChat(data.channel, data.fromClientId, data.interests || []);
+      });
 
-        // Enter presence so others can see we are searching
-        await lobby.presence.enter({ searching: true });
-        
-        // Check if anyone else is already waiting
-        const presenceSet = await lobby.presence.get();
-        const otherWaiters = presenceSet.filter(p => p.clientId !== ably.auth.clientId && p.data?.searching);
-        
-        if (otherWaiters.length > 0 && !alreadyMatchedRef.current) {
-           alreadyMatchedRef.current = true;
-           const target = otherWaiters[Math.floor(Math.random() * otherWaiters.length)];
-           const newChatChannelId = `chat_${Math.random().toString(36).substring(2)}`;
-           
-           await lobby.publish('offer', { target: target.clientId, channel: newChatChannelId });
-           
-           lobby.unsubscribe();
-           lobby.presence.leave().catch(() => {});
-           joinChat(newChatChannelId, "Stranger");
-        }
-    } catch (e: any) {
-        console.warn("Matchmaking initialization error:", e.message);
-        safeSetStatus('idle');
-    } finally {
-        isActionPending.current = false;
-    }
-  };
+      lobby.presence.subscribe(['enter', 'update'], () => {
+        void attemptMatch(fallbackWidenedRef.current);
+      });
 
-  const joinChat = async (channelId: string, name: string) => {
-     // Clear pending actions if we were searching
-     isActionPending.current = true;
-     
-     safeSetStatus('matched');
-     safeSetMessages(prev => [...prev, { id: 'sys_' + Date.now(), text: 'Stranger found! Say hi.', sender: 'system', timestamp: Date.now() }]);
-     safeSetStrangerName(name);
-     const ably = ablyRef.current!;
+      await lobby.presence.enter({
+        searching: true,
+        interests: normalizedOptions.interests,
+        matchMode: normalizedOptions.matchMode,
+        startedAt: Date.now(),
+        searchId: searchIdRef.current,
+        version: 2,
+      } satisfies LobbyPresenceData);
 
-     try {
-         // Fully clean up any previous chat channel before joining a new one
-         if (chatChannelRef.current) {
-             const prevChat = chatChannelRef.current;
-             chatChannelRef.current = null;
-             prevChat.unsubscribe();
-             prevChat.presence.unsubscribe();
-             await prevChat.presence.leave().catch(() => {});
-             try { prevChat.detach(); } catch(e) { /* ignore error */ }
-         }
+      await attemptMatch(false);
 
-         const chatChannel = ably.channels.get(channelId);
-         chatChannelRef.current = chatChannel;
-
-         // Enter presence to track disconnects
-         await chatChannel.presence.enter();
-         
-         chatChannel.presence.subscribe('leave', (member) => {
-             if (member.clientId !== ably.auth.clientId) {
-                safeSetStatus('idle');
-                safeSetIsStrangerTyping(false);
-                safeSetMessages(prev => [...prev, { id: 'disc_' + Date.now(), text: 'Stranger has disconnected.', sender: 'system', timestamp: Date.now() }]);
-                chatChannel.unsubscribe();
-                chatChannel.presence.unsubscribe();
-                try { chatChannel.detach(); } catch(e) { /* ignore error */ }
-                chatChannelRef.current = null;
-             }
-         });
-
-         // Listen for incoming messages
-         chatChannel.subscribe('message', (msg) => {
-             if (msg.connectionId !== ably.connection.id) {
-                 safeSetMessages(prev => [...prev, { id: msg.id, text: msg.data.text, sender: 'stranger', timestamp: msg.timestamp }]);
-                 safeSetIsStrangerTyping(false);
-             }
-         });
-
-         chatChannel.subscribe('typing', (msg) => {
-             if (msg.connectionId !== ably.connection.id) {
-                 safeSetIsStrangerTyping(msg.data.isTyping);
-             }
-         });
-     } catch (e: any) {
-         console.warn("Chat session error:", e.message);
-         safeSetStatus('idle');
-     } finally {
-         isActionPending.current = false;
-     }
-  };
-
-  const sendMessage = (text: string) => {
-     if (chatChannelRef.current && status === 'matched') {
-         chatChannelRef.current.publish('message', { text });
-         safeSetMessages(prev => [...prev, { id: Math.random().toString(), text, sender: 'me', timestamp: Date.now() }]);
-     }
-  };
-
-  const sendTypingIndicator = (isTyping: boolean) => {
-      if (status === 'matched' && chatChannelRef.current) {
-          chatChannelRef.current.publish('typing', { isTyping }).catch(() => {});
+      clearFallbackTimer();
+      if (!alreadyMatchedRef.current) {
+        fallbackTimerRef.current = setTimeout(() => {
+          fallbackWidenedRef.current = true;
+          safeSetSearchHint('Widening search so you are not stuck in the void...');
+          void attemptMatch(true);
+        }, normalizedOptions.matchMode === 'shared' ? SHARED_MATCH_FALLBACK_MS : 2500);
       }
-  };
+    } catch (e: any) {
+      console.warn('Matchmaking initialization error:', e.message);
+      safeSetStatus('idle');
+      addSystemMessage('Could not enter the Stranger lobby. Try again.', 'danger');
+    } finally {
+      isActionPending.current = false;
+    }
+  }, [addSystemMessage, attemptMatch, cleanupChat, cleanupLobby, clearFallbackTimer, joinChat, safeSetCurrentOptions, safeSetIsStrangerTyping, safeSetMessages, safeSetPeerInterests, safeSetSearchHint, safeSetStatus, safeSetStrangerName]);
 
-  const stopSearch = async () => {
-     if (isActionPending.current) return;
-     isActionPending.current = true;
+  const sendMessage = useCallback((text: string) => {
+    const cleaned = sanitizeMessage(text);
+    if (!cleaned || !chatChannelRef.current || status !== 'matched') return { ok: false, reason: 'not_ready' };
 
-     try {
-         if (lobbyChannelRef.current) {
-             const lobby = lobbyChannelRef.current;
-             lobbyChannelRef.current = null;
-             lobby.unsubscribe();
-             lobby.presence.unsubscribe();
-             await lobby.presence.leave().catch(() => {});
-             try { lobby.detach(); } catch(e) { /* ignore error */ }
-         }
-         if (chatChannelRef.current) {
-             const chat = chatChannelRef.current;
-             chatChannelRef.current = null;
-             chat.unsubscribe();
-             chat.presence.unsubscribe();
-             await chat.presence.leave().catch(() => {});
-             try { chat.detach(); } catch(e) { /* ignore error */ }
-         }
-     } catch (e) {
-         /* ignore error */
-     }
+    const now = Date.now();
+    const remainingCooldown = MIN_MESSAGE_INTERVAL_MS - (now - lastMessageAtRef.current);
+    if (remainingCooldown > 0) {
+      return { ok: false, reason: 'cooldown', remainingMs: remainingCooldown };
+    }
 
+    lastMessageAtRef.current = now;
+    chatChannelRef.current.publish('message', { text: cleaned }).catch(() => {
+      addSystemMessage('Message failed to send. Check your realtime connection.', 'danger');
+    });
+    safeSetMessages((prev) => [...prev, { id: createId('me'), text: cleaned, sender: 'me', timestamp: now }]);
+    resetIdleTimer();
+    return { ok: true, text: cleaned };
+  }, [addSystemMessage, resetIdleTimer, safeSetMessages, status]);
+
+  const sendTypingIndicator = useCallback((isTyping: boolean) => {
+    if (status === 'matched' && chatChannelRef.current) {
+      chatChannelRef.current.publish('typing', { isTyping }).catch(() => {});
+    }
+  }, [status]);
+
+  const stopSearch = useCallback(async (message = 'You disconnected.') => {
+    if (isActionPending.current) return;
+    isActionPending.current = true;
+
+    try {
+      await cleanupLobby();
+      await cleanupChat();
+    } finally {
+      alreadyMatchedRef.current = false;
+      currentPeerIdRef.current = null;
       safeSetStatus('idle');
       safeSetIsStrangerTyping(false);
-      safeSetMessages(prev => [...prev, { id: 'stop_' + Date.now(), text: 'You disconnected.', sender: 'system', timestamp: Date.now() }]);
+      safeSetPeerInterests([]);
+      safeSetSearchHint('Ready for anonymous text chat.');
+      addSystemMessage(message, 'warning');
       isActionPending.current = false;
-   };
+    }
+  }, [addSystemMessage, cleanupChat, cleanupLobby, safeSetIsStrangerTyping, safeSetPeerInterests, safeSetSearchHint, safeSetStatus]);
 
-   const skip = async () => {
-       await stopSearch();
-       await startSearch();
-   };
+  const skip = useCallback(async () => {
+    if (currentPeerIdRef.current) {
+      blockedPeersRef.current.add(currentPeerIdRef.current);
+      safeSetBlockedCount(blockedPeersRef.current.size);
+    }
+    const options = optionsRef.current;
+    await stopSearch('You skipped this stranger. Searching again...');
+    await startSearch(options);
+  }, [safeSetBlockedCount, startSearch, stopSearch]);
 
-   return { status, messages, sendMessage, startSearch, stopSearch, skip, strangerName, onlineCount, isStrangerTyping, sendTypingIndicator };
- }
+  const reportAndSkip = useCallback(async () => {
+    if (currentPeerIdRef.current) {
+      blockedPeersRef.current.add(currentPeerIdRef.current);
+      safeSetBlockedCount(blockedPeersRef.current.size);
+    }
+    addSystemMessage('This stranger was avoided for this browser session. No report was stored.', 'warning');
+    const options = optionsRef.current;
+    await stopSearch('Safety skip activated. Searching for someone else...');
+    await startSearch(options);
+  }, [addSystemMessage, safeSetBlockedCount, startSearch, stopSearch]);
+
+  const clearMessages = useCallback(() => {
+    safeSetMessages([]);
+    addSystemMessage('Local chat cleared. The session is still active.', 'default');
+  }, [addSystemMessage, safeSetMessages]);
+
+  return {
+    status,
+    messages,
+    sendMessage,
+    startSearch,
+    stopSearch,
+    skip,
+    reportAndSkip,
+    clearMessages,
+    strangerName,
+    onlineCount,
+    isStrangerTyping,
+    sendTypingIndicator,
+    connectionState,
+    searchHint,
+    peerInterests,
+    currentOptions,
+    blockedCount,
+    maxMessageLength: MAX_MESSAGE_LENGTH,
+  };
+}


### PR DESCRIPTION
### Motivation
- Improve the anonymous "Stranger" chat experience with clearer UI, richer matchmaking controls, and more robust realtime behaviour.
- Add interest-based matching and match-mode options so users can prefer shared tags or random pairing.
- Harden message handling with sanitization, length limits, cooldowns and idle timeouts to reduce spam and bad input.
- Surface realtime/connection state and safety actions (skip/report/clear) to give users more control during sessions.

### Description
- Revamped the chat UI in `StrangerChat.tsx` with an improved lobby, interest picker (`STRANGER_INTERESTS`), match mode toggles, connection status indicators, search hints, composer notice, and a textarea with Enter-to-send and Shift+Enter behavior.
- Overhauled `useStrangerMatch.tsx`: introduced typed models (`StrangerStatus`, `StrangerMatchMode`, `StrangerConnectionState`), persistent client id generation, interest normalization, presence-based matchmaking (`chooseCandidate`), fallback widening, idle timeout, blocked-peers handling, message sanitization (`sanitizeMessage`), max length and per-message cooldown, and new actions `startSearch`, `stopSearch`, `skip`, `reportAndSkip`, `clearMessages` and enhanced `sendMessage`/`sendTypingIndicator` behavior.
- Improved Ably integration: global, lobby and chat channels are managed separately, connection state changes are reflected in UI, presence tracking is more robust, and errors produce system messages with tone metadata.
- Enhanced `MessageList.tsx` UI: empty-state illustration, system message tones/styles/icons, refined message bubbles, typing indicator layout, and scroll behavior (`block: 'end'`).

### Testing
- Ran a TypeScript build (`npm run build`) to validate types and bundling and it completed successfully.
- Executed linter (`npm run lint`) to catch stylistic issues and it passed without errors.
- Ran unit tests (`npm test`) and basic test suite checks which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07dd0edcb4832bb47d74594b738089)