### PR TITLE
Add animated route/page transitions, motion UI tweaks, image fade-in, and realtime new-posts pill

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HelmetProvider } from "react-helmet-async";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import { AuthProvider } from "@/hooks/useAuth";
 import { ThemeProvider } from "@/components/theme-provider";
 import { syncTime } from "@/lib/utils";
@@ -25,6 +25,8 @@ import GoogleAnalytics from "@/components/GoogleAnalytics";
 import { FloatingWhisperBubble } from "@/components/FloatingWhisperBubble";
 import { PushNotificationPrompt } from "@/components/PushNotificationPrompt";
 import MfaSessionGuard from "@/components/MfaSessionGuard";
+import { AnimatePresence } from "framer-motion";
+import PageWrapper from "@/components/PageWrapper";
 
 const Index = lazy(() => import("@/pages/Index"));
 const AuthPage = lazy(() => import("@/pages/AuthPage"));
@@ -56,6 +58,50 @@ const MAINTENANCE_MODE = false;
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
 const queryClient = new QueryClient();
+
+const AppRoutes = () => {
+  const location = useLocation();
+
+  return (
+    <AnimatePresence mode="wait">
+      <Routes location={location} key={location.pathname}>
+        <Route path="/" element={<PageWrapper><Index /></PageWrapper>} />
+        <Route path="/auth" element={<PageWrapper><AuthPage /></PageWrapper>} />
+        <Route path="/auth/mfa" element={<PageWrapper><MfaChallengePage /></PageWrapper>} />
+        <Route path="/auth/update-password" element={<PageWrapper><UpdatePasswordPage /></PageWrapper>} />
+        <Route path="/about" element={<PageWrapper><AboutPage /></PageWrapper>} />
+        <Route path="/terms" element={<PageWrapper><TermsPage /></PageWrapper>} />
+        <Route path="/privacy" element={<PageWrapper><PrivacyPage /></PageWrapper>} />
+        <Route path="/post/:postId" element={<PageWrapper><PostPage /></PageWrapper>} />
+        <Route path="/search" element={<PageWrapper><SearchPage /></PageWrapper>} />
+        <Route path="/whispers" element={<PageWrapper><WhispersPage /></PageWrapper>} />
+        <Route path="/whispers/community" element={<PageWrapper><CommunityChat /></PageWrapper>} />
+        <Route path="/whisper/:username" element={<PageWrapper><ChatPage /></PageWrapper>} />
+        <Route path="/stranger" element={<PageWrapper><StrangerPage /></PageWrapper>} />
+        <Route path="/play" element={<PageWrapper><PlayPage /></PageWrapper>} />
+        <Route path="/game-house" element={<PageWrapper><GameHouseGallery /></PageWrapper>} />
+        <Route path="/game-house/submit" element={<PageWrapper><GameHouseSubmit /></PageWrapper>} />
+        <Route path="/game-house/edit/:id" element={<PageWrapper><GameHouseEdit /></PageWrapper>} />
+        <Route path="/game-house/play/:id" element={<PageWrapper><GameHousePlay /></PageWrapper>} />
+        <Route path="/qna/:username" element={<PageWrapper><QnaPage /></PageWrapper>} />
+        <Route path="/qna-inbox" element={<PageWrapper><QnaInbox /></PageWrapper>} />
+        <Route
+          path="/admin"
+          element={(
+            <PageWrapper>
+              <RequireAdmin>
+                <AdminPage />
+              </RequireAdmin>
+            </PageWrapper>
+          )}
+        />
+        <Route path="/u/:username" element={<PageWrapper><ProfilePage /></PageWrapper>} />
+        <Route path="/settings" element={<PageWrapper><SettingsPage /></PageWrapper>} />
+        <Route path="*" element={<PageWrapper><NotFound /></PageWrapper>} />
+      </Routes>
+    </AnimatePresence>
+  );
+};
 
 const App = () => {
   useEffect(() => {
@@ -102,39 +148,7 @@ const App = () => {
                       </div>
                     }
                   >
-                    <Routes>
-                      <Route path="/" element={<Index />} />
-                      <Route path="/auth" element={<AuthPage />} />
-                      <Route path="/auth/mfa" element={<MfaChallengePage />} />
-                      <Route path="/auth/update-password" element={<UpdatePasswordPage />} />
-                      <Route path="/about" element={<AboutPage />} />
-                      <Route path="/terms" element={<TermsPage />} />
-                      <Route path="/privacy" element={<PrivacyPage />} />
-                      <Route path="/post/:postId" element={<PostPage />} />
-                      <Route path="/search" element={<SearchPage />} />
-                      <Route path="/whispers" element={<WhispersPage />} />
-                      <Route path="/whispers/community" element={<CommunityChat />} />
-                      <Route path="/whisper/:username" element={<ChatPage />} />
-                      <Route path="/stranger" element={<StrangerPage />} />
-                      <Route path="/play" element={<PlayPage />} />
-                      <Route path="/game-house" element={<GameHouseGallery />} />
-                      <Route path="/game-house/submit" element={<GameHouseSubmit />} />
-                      <Route path="/game-house/edit/:id" element={<GameHouseEdit />} />
-                      <Route path="/game-house/play/:id" element={<GameHousePlay />} />
-                      <Route path="/qna/:username" element={<QnaPage />} />
-                      <Route path="/qna-inbox" element={<QnaInbox />} />
-                      <Route
-                        path="/admin"
-                        element={(
-                          <RequireAdmin>
-                            <AdminPage />
-                          </RequireAdmin>
-                        )}
-                      />
-                      <Route path="/u/:username" element={<ProfilePage />} />
-                      <Route path="/settings" element={<SettingsPage />} />
-                      <Route path="*" element={<NotFound />} />
-                    </Routes>
+                    <AppRoutes />
                   </Suspense>
                 </AuthProvider>
               </BrowserRouter>

--- a/src/components/DataSaverImage.tsx
+++ b/src/components/DataSaverImage.tsx
@@ -27,15 +27,32 @@ export default function DataSaverImage({
   );
 
   const [isUnlocked, setIsUnlocked] = useState(!shouldGate);
+  const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
     setIsUnlocked(!shouldGate);
+    setIsLoaded(false);
   }, [shouldGate, src]);
 
   if (!src) return null;
+  const safeAlt = (alt ?? "").replace(/[<>]/g, "");
+  const safeSrc = getSafeUrl(src);
+  const handleLoad: ImgHTMLAttributes<HTMLImageElement>["onLoad"] = (event) => {
+    setIsLoaded(true);
+    props.onLoad?.(event);
+  };
 
   if (!shouldGate || isUnlocked) {
-    return <img src={getSafeUrl(src)} alt={alt} className={className} {...props} loading={props.loading || "lazy"} />;
+    return (
+      <img
+        src={safeSrc}
+        alt={safeAlt}
+        className={cn("opacity-0 transition-opacity duration-250", isLoaded && "opacity-100", className)}
+        {...props}
+        loading={props.loading || "lazy"}
+        onLoad={handleLoad}
+      />
+    );
   }
 
   const unlock = (event: MouseEvent<HTMLDivElement> | KeyboardEvent<HTMLDivElement>) => {

--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -1,0 +1,21 @@
+import { motion } from "framer-motion";
+import { ReactNode } from "react";
+
+interface PageWrapperProps {
+  children: ReactNode;
+}
+
+const PageWrapper = ({ children }: PageWrapperProps) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -4 }}
+      transition={{ duration: 0.18, ease: "easeOut" }}
+    >
+      {children}
+    </motion.div>
+  );
+};
+
+export default PageWrapper;

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -24,6 +24,7 @@ import EditPostDialog from "@/components/EditPostDialog";
 import PostLikesDialog from "@/components/PostLikesDialog";
 import DataSaverImage from "@/components/DataSaverImage";
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+const MotionLink = motion(Link);
 
 const LivePreviewModal = ({ code, language, isOpen, onOpenChange }: { code: string; language: string; isOpen: boolean; onOpenChange: (open: boolean) => void }) => {
   const getSrcDoc = () => {
@@ -137,6 +138,7 @@ const CodeBlockWithPreview = ({
     );
 };
 interface PostCardProps {
+  index?: number;
   post: PostWithProfile;
   onLike: (postId: string, liked: boolean) => void;
   onBookmark: (postId: string, bookmarked: boolean) => void;
@@ -181,7 +183,7 @@ function timeAgo(dateStr: string): string {
   return `${Math.floor(days / 30)}mo`;
 }
 
-const PostCard = memo(({ post, onLike, onBookmark, onDelete, onPostEdited }: PostCardProps) => {
+const PostCard = memo(({ post, onLike, onBookmark, onDelete, onPostEdited, index = 0 }: PostCardProps) => {
   const { user } = useAuth();
   const { recordView } = usePostViews();
   const [showMenu, setShowMenu] = useState(false);
@@ -391,6 +393,7 @@ const PostCard = memo(({ post, onLike, onBookmark, onDelete, onPostEdited }: Pos
       ref={articleRef}
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: Math.min(index * 0.06, 0.3), duration: 0.24, ease: "easeOut" }}
       className="gum-card p-5 mb-4"
     >
       <div className="flex gap-3">
@@ -399,7 +402,7 @@ const PostCard = memo(({ post, onLike, onBookmark, onDelete, onPostEdited }: Pos
           className="w-10 h-10 rounded-[3px] gum-border bg-secondary flex items-center justify-center font-bold text-sm shrink-0 overflow-hidden hover:opacity-80 transition-opacity"
         >
           {post.profiles?.avatar_url ? (
-            <img src={post.profiles.avatar_url} alt={post.profiles.username} className="w-full h-full object-cover" loading="lazy" />
+            <img src={post.profiles.avatar_url} alt={post.profiles.username} className="w-full h-full object-cover opacity-0 transition-opacity duration-250" loading="lazy" onLoad={(event) => event.currentTarget.classList.replace("opacity-0", "opacity-100")} />
           ) : initials}
         </button>
         <div className="flex-1 min-w-0">
@@ -669,15 +672,16 @@ const PostCard = memo(({ post, onLike, onBookmark, onDelete, onPostEdited }: Pos
                 {post.likes_count}
               </button>
             </div>
-            <Link
+            <MotionLink
               to={`/post/${post.id}`}
               className="shrink-0 flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-primary transition-colors"
+              whileTap={{ scale: 0.9 }}
             >
               <MessageSquare size={15} />
               {post.comments_count}
-            </Link>
+            </MotionLink>
             {!isOwner && (
-              <button
+              <motion.button
                 onClick={() => {
                   if (!user) {
                     toast.error("Please sign in to send messages");
@@ -687,16 +691,18 @@ const PostCard = memo(({ post, onLike, onBookmark, onDelete, onPostEdited }: Pos
                 }}
                 className="shrink-0 flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-primary transition-colors"
                 title="Whisper to author"
+                whileTap={{ scale: 0.9 }}
               >
                 <Send size={15} />
-              </button>
+              </motion.button>
             )}
-            <button
+            <motion.button
               onClick={() => onBookmark(post.id, post.user_bookmarked)}
               className={`shrink-0 flex items-center gap-1.5 text-xs font-medium transition-colors ${post.user_bookmarked ? "text-yellow-500" : "text-muted-foreground hover:text-yellow-500"}`}
+              whileTap={{ scale: 0.9 }}
             >
               <Bookmark size={15} fill={post.user_bookmarked ? "currentColor" : "none"} />
-            </button>
+            </motion.button>
 
             {/* Translation Button */}
             {!isAlreadyEnglish && (
@@ -717,13 +723,14 @@ const PostCard = memo(({ post, onLike, onBookmark, onDelete, onPostEdited }: Pos
               </button>
             )}
 
-            <button
+            <motion.button
               onClick={handleShare}
               className="shrink-0 flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
               title="Share post"
+              whileTap={{ scale: 0.9 }}
             >
               <Share size={15} />
-            </button>
+            </motion.button>
           </div>
           <PostLikesDialog
             postId={post.id}

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -10,7 +10,7 @@ const ScrollToTop = () => {
         // restores the previous scroll position naturally.
         if (navigationType === "POP") return;
 
-        window.scrollTo(0, 0);
+        window.scrollTo({ top: 0, left: 0, behavior: "instant" });
     }, [pathname, navigationType]);
 
     return null;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useNavigationType } from "react-router-dom";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import Navbar from "@/components/Navbar";
 import ComposePost from "@/components/ComposePost";
 import PostCard from "@/components/PostCard";
@@ -10,6 +10,8 @@ import { FrogLoader } from "@/components/ui/FrogLoader";
 import { Helmet } from "react-helmet-async";
 import { PostSkeleton } from "@/components/ui/skeleton";
 import { useTranslation } from "react-i18next";
+import { supabase } from "@/integrations/supabase/client";
+import { AnimatePresence, motion } from "framer-motion";
 
 const Index = () => {
   const { user, loading: authLoading } = useAuth();
@@ -23,11 +25,13 @@ const Index = () => {
     deletePost,
     fetchNextPage,
     hasNextPage,
-    isFetchingNextPage
+    isFetchingNextPage,
+    refetch
   } = usePosts();
   const navigate = useNavigate();
   const navigationType = useNavigationType();
   const observerRef = useRef<HTMLDivElement>(null);
+  const [showNewPostsPill, setShowNewPostsPill] = useState(false);
   const paginationRequestInFlightRef = useRef(false);
   const scrollRestoredRef = useRef(false);
 
@@ -93,6 +97,25 @@ const Index = () => {
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
+  useEffect(() => {
+    const channel = supabase
+      .channel(`posts-feed-${Math.random().toString(36).slice(2)}`)
+      .on("postgres_changes", { event: "INSERT", schema: "public", table: "posts" }, () => {
+        if (window.scrollY > 300) setShowNewPostsPill(true);
+      })
+      .subscribe();
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, []);
+
+  const handleNewPostsClick = async () => {
+    await refetch();
+    setShowNewPostsPill(false);
+    window.scrollTo({ top: 0, left: 0, behavior: "instant" });
+  };
+
   if (authLoading) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">
@@ -132,6 +155,20 @@ const Index = () => {
               </div>
             )}
 
+            <AnimatePresence>
+              {showNewPostsPill && (
+                <motion.button
+                  initial={{ opacity: 0, y: -8, scale: 0.96 }}
+                  animate={{ opacity: 1, y: 0, scale: 1 }}
+                  exit={{ opacity: 0, y: -8, scale: 0.96 }}
+                  transition={{ duration: 0.18, ease: "easeOut" }}
+                  onClick={() => void handleNewPostsClick()}
+                  className="sticky top-20 z-20 mb-4 mx-auto block px-4 py-1.5 rounded-full bg-primary text-primary-foreground text-xs font-semibold shadow-md"
+                >
+                  ↑ New posts
+                </motion.button>
+              )}
+            </AnimatePresence>
             {postsLoading ? (
               <div className="space-y-4">
                 {[1, 2, 3].map(i => <PostSkeleton key={i} />)}
@@ -143,9 +180,10 @@ const Index = () => {
               </div>
             ) : (
               <div className="space-y-6">
-                {posts.map((post) => (
+                {posts.map((post, index) => (
                   <PostCard
                     key={post.id}
+                    index={index}
                     post={post}
                     onLike={toggleLike}
                     onBookmark={toggleBookmark}

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -7,6 +7,7 @@ import PostCard from "@/components/PostCard";
 import Sidebar from "@/components/Sidebar";
 import { ArrowLeft, Send, MessageSquare, MoreHorizontal, Trash2, Languages, Reply } from "lucide-react";
 import { FrogLoader } from "@/components/ui/FrogLoader";
+import { PostSkeleton } from "@/components/ui/skeleton";
 import { useAuth } from "@/hooks/useAuth";
 import { toast } from "sonner";
 import { Helmet } from "react-helmet-async";
@@ -529,8 +530,9 @@ const PostPage = () => {
                         </button>
 
                         {loading ? (
-                            <div className="flex justify-center py-12">
-                                <FrogLoader className="" size={24} />
+                            <div className="space-y-6">
+                                <PostSkeleton />
+                                <PostSkeleton />
                             </div>
                         ) : !post ? (
                             <div className="gum-card p-8 text-center">


### PR DESCRIPTION
### Motivation

- Improve UX with smooth page and element transitions across the app.
- Make images load more gracefully and safely while preserving the data-saver gating behavior.
- Notify users of incoming posts in realtime and reduce perceived loading during page/post views.

### Description

- Added a `PageWrapper` component (framer-motion) and an `AppRoutes` wrapper using `AnimatePresence` and `useLocation` to enable animated route transitions and wrapped every route with `PageWrapper`.
- Enhanced `PostCard` to accept an `index` prop and stagger entrance animations via `motion.article`, converted several interactive elements to `motion.button`/`MotionLink` with `whileTap` feedback, and added avatar fade-in on load.
- Updated `DataSaverImage` to track load state, sanitize `alt` and `src` via `getSafeUrl`, apply a fade-in transition on load, and reset state when `src` changes while preserving data-saver gating.
- Added a Supabase realtime subscription in `Index` to show a sticky animated “↑ New posts” pill when new posts arrive off-screen, wired `refetch` to refresh the feed, passed `index` to `PostCard` for list animations, and replaced some loaders with `PostSkeleton` placeholders.
- Small UX tweaks include changing `ScrollToTop` to use `window.scrollTo` with options for instant scrolling and replacing the single-page `Routes` block with the new `AppRoutes` component.

### Testing

- Ran a production type-check and build via `yarn build` and it completed successfully.
- Ran the test suite with `yarn test` and all tests passed.
- Ran linting via `yarn lint` and the codebase passed lint checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca512396083308ab99574213d550e)