### PR TITLE
Show frog loader instantly on first app load

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
   <meta name="keywords" content="genjutsu, developer social network, ephemeral chat, 24 hour posts, coding community" />
   <link rel="icon" href="/fav.jpg">
   <link rel="apple-touch-icon" href="/fav.jpg">
+  <link rel="preload" as="image" href="/frog-loader.gif" fetchpriority="high" />
   <meta name="theme-color" content="transparent" />
   <meta name="author" content="Ovi ren" />
 
@@ -58,7 +59,11 @@
           href="/api/llm-content">/api/llm-content</a>.</p>
     </main>
   </noscript>
-  <div id="root"></div>
+  <div id="root">
+    <div id="boot-loader" style="min-height:100vh;display:flex;align-items:center;justify-content:center;">
+      <img src="/frog-loader.gif" alt="Loading..." width="56" height="56" style="object-fit:contain;mix-blend-mode:multiply;" />
+    </div>
+  </div>
   <script type="module" src="/src/main.tsx"></script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     (function () {
       let theme = null;
       try {
-        theme = localStorage.getItem('vite-ui-theme');
+        theme = localStorage.getItem('genjutsu-theme');
       } catch (e) { /* ignore */ }
       const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
       if (theme === 'dark' || (!theme && systemDark)) {
@@ -18,6 +18,11 @@
       }
     })();
   </script>
+
+  <style>
+    html, body { margin: 0; background: #ffffff; }
+    html.dark body { background: #09090b; }
+  </style>
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>genjutsu</title>
@@ -60,7 +65,7 @@
     </main>
   </noscript>
   <div id="root">
-    <div id="boot-loader" style="min-height:100vh;display:flex;align-items:center;justify-content:center;">
+    <div id="boot-loader" style="min-height:100vh;display:flex;align-items:center;justify-content:center;background:inherit;">
       <img src="/frog-loader.gif" alt="Loading..." width="56" height="56" style="object-fit:contain;mix-blend-mode:multiply;" />
     </div>
   </div>


### PR DESCRIPTION
### Motivation
- The frog loader was not visible immediately because the browser only fetched the GIF and React mounted the suspense fallback later during app bootstrap and config loading. 
- A small, static preload + boot UI ensures the loader appears before React hydrates so users see immediate feedback on first open.

### Description
- Added a high-priority preload for the loader GIF in `index.html` via `<link rel="preload" as="image" href="/frog-loader.gif" fetchpriority="high" />` to request the asset early.
- Injected a lightweight static boot loader markup inside the `#root` element in `index.html` that displays the frog GIF while the app and config load (`<div id="boot-loader">...</div>`).
- No runtime code changes to React components were made; this is a static HTML-level improvement to reduce first-paint delay.

### Testing
- Built the production bundle with `npm run build` (calls `vite build`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d7682f408322951a8698c67b01a2)