### PR TITLE
Fix initial theme/grid hydration to prevent background grid flash

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,13 +8,31 @@
 
   <script>
     (function () {
-      let theme = null;
-      try {
-        theme = localStorage.getItem('genjutsu-theme');
-      } catch (e) { /* ignore */ }
+      const root = document.documentElement;
+      const appearanceKey = 'genjutsu-appearance';
+      const get = (key) => {
+        try {
+          return localStorage.getItem(key);
+        } catch (e) {
+          return null;
+        }
+      };
+
+      const theme = get(`${appearanceKey}-theme`) || get('genjutsu-theme');
+      const preset = get(`${appearanceKey}-preset`);
+      const grid = get(`${appearanceKey}-grid`);
+
       const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      if (theme === 'dark' || (!theme && systemDark)) {
-        document.documentElement.classList.add('dark');
+      if (theme === 'dark' || (theme !== 'light' && !theme && systemDark) || (theme === 'system' && systemDark)) {
+        root.classList.add('dark');
+      }
+
+      if (preset) {
+        root.setAttribute('data-theme-preset', preset);
+      }
+
+      if (grid) {
+        root.setAttribute('data-grid', grid);
       }
     })();
   </script>


### PR DESCRIPTION
### Motivation
- The background grid and theme could briefly flash to defaults on page reload because those attributes were only set in a post-mount React effect, so the boot script now applies stored appearance values before hydration.

### Description
- Replace the early boot script in `index.html` to read the `genjutsu-appearance-*` keys and apply `data-grid` and `data-theme-preset` to `document.documentElement`, enhance the dark-mode detection logic, and keep a fallback to the legacy `genjutsu-theme` key.

### Testing
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15dddf6974832294cc2d915cdbe8b1)