### PR TITLE
Introduce FullScreenFrogLoader and replace inline loading placeholders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@
 
 import { lazy, Suspense, useEffect } from "react";
 import { MaintenancePage } from "@/components/MaintenancePage";
-import { FrogLoader } from "@/components/ui/FrogLoader";
+import { FullScreenFrogLoader } from "@/components/ui/FrogLoader";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -96,11 +96,7 @@ const App = () => {
                   <FloatingWhisperBubble />
                   <PushNotificationPrompt />
                   <Suspense
-                    fallback={
-                      <div className="flex h-screen items-center justify-center">
-                        <FrogLoader size={32} />
-                      </div>
-                    }
+                    fallback={<FullScreenFrogLoader />}
                   >
                     <Routes>
                       <Route path="/" element={<Index />} />

--- a/src/components/RequireAdmin.tsx
+++ b/src/components/RequireAdmin.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
 import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "@/hooks/useAuth";
-import { FrogLoader } from "@/components/ui/FrogLoader";
+import { FullScreenFrogLoader } from "@/components/ui/FrogLoader";
 
 interface RequireAdminProps {
   children: ReactNode;
@@ -12,11 +12,7 @@ const RequireAdmin = ({ children }: RequireAdminProps) => {
   const location = useLocation();
 
   if (loading) {
-    return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <FrogLoader className="" size={24} />
-      </div>
-    );
+    return <FullScreenFrogLoader />;
   }
 
   if (!user) {

--- a/src/components/ui/FrogLoader.tsx
+++ b/src/components/ui/FrogLoader.tsx
@@ -1,5 +1,7 @@
 import { cn } from "@/lib/utils";
 
+export const APP_LOADER_SIZE = 32;
+
 export const FrogLoader = ({ size = 24, className }: { size?: number, className?: string }) => {
   // Frogs need to be bigger than generic line-art spinners to be visible.
   // We double the visual size, but contain it in a relative wrapper of the original size
@@ -21,3 +23,9 @@ export const FrogLoader = ({ size = 24, className }: { size?: number, className?
     </span>
   );
 };
+
+export const FullScreenFrogLoader = ({ className }: { className?: string }) => (
+  <div className={cn("min-h-screen bg-background flex items-center justify-center", className)}>
+    <FrogLoader size={APP_LOADER_SIZE} />
+  </div>
+);

--- a/src/pages/GameHouseEdit.tsx
+++ b/src/pages/GameHouseEdit.tsx
@@ -11,7 +11,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useAuth } from "@/hooks/useAuth";
 import { toast } from "sonner";
 import { ArrowLeft, Code } from "lucide-react";
-import { FrogLoader } from "@/components/ui/FrogLoader";
+import { FrogLoader, FullScreenFrogLoader } from "@/components/ui/FrogLoader";
 import { useQuery } from "@tanstack/react-query";
 
 export default function GameHouseEdit() {
@@ -86,13 +86,7 @@ export default function GameHouseEdit() {
   }, [game, user, navigate, isInitialized]);
 
   if (!user || isLoading) {
-    return (
-      <div className="min-h-screen bg-background text-foreground flex flex-col">
-        <div className="flex-1 flex items-center justify-center">
-          <FrogLoader size={24} />
-        </div>
-      </div>
-    );
+    return <FullScreenFrogLoader />;
   }
 
   if (isError) {

--- a/src/pages/GameHousePlay.tsx
+++ b/src/pages/GameHousePlay.tsx
@@ -6,7 +6,7 @@ import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft, Maximize2, AlertTriangle, RotateCcw, Pencil } from "lucide-react";
-import { FrogLoader } from "@/components/ui/FrogLoader";
+import { FrogLoader, FullScreenFrogLoader } from "@/components/ui/FrogLoader";
 import { toast } from "sonner";
 import { useAuth } from "@/hooks/useAuth";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -148,13 +148,7 @@ export default function GameHousePlay() {
   };
 
   if (isLoading) {
-    return (
-      <div className="min-h-screen bg-background text-foreground flex flex-col">
-        <div className="flex-1 flex items-center justify-center">
-              <FrogLoader size={24} />
-        </div>
-      </div>
-    );
+    return <FullScreenFrogLoader />;
   }
 
   if (isError || !game) {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,7 +6,7 @@ import PostCard from "@/components/PostCard";
 import Sidebar from "@/components/Sidebar";
 import { useAuth } from "@/hooks/useAuth";
 import { usePosts } from "@/hooks/usePosts";
-import { FrogLoader } from "@/components/ui/FrogLoader";
+import { FrogLoader, FullScreenFrogLoader } from "@/components/ui/FrogLoader";
 import { Helmet } from "react-helmet-async";
 import { PostSkeleton } from "@/components/ui/skeleton";
 import { useTranslation } from "react-i18next";
@@ -95,11 +95,7 @@ const Index = () => {
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   if (authLoading) {
-    return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <FrogLoader className="" size={24} />
-      </div>
-    );
+    return <FullScreenFrogLoader />;
   }
 
   return (

--- a/src/pages/MfaChallengePage.tsx
+++ b/src/pages/MfaChallengePage.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { Helmet } from "react-helmet-async";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/hooks/useAuth";
-import { FrogLoader } from "@/components/ui/FrogLoader";
+import { FrogLoader, FullScreenFrogLoader } from "@/components/ui/FrogLoader";
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp";
 
 type LocationState = {
@@ -89,11 +89,7 @@ const MfaChallengePage = () => {
   };
 
   if (loading || screenLoading) {
-    return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <FrogLoader size={24} className="" />
-      </div>
-    );
+    return <FullScreenFrogLoader />;
   }
 
   return (

--- a/src/pages/QnaInbox.tsx
+++ b/src/pages/QnaInbox.tsx
@@ -7,7 +7,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useProfile } from "@/hooks/useProfile";
 import Navbar from "@/components/Navbar";
 import Sidebar from "@/components/Sidebar";
-import { FrogLoader } from "@/components/ui/FrogLoader";
+import { FrogLoader, FullScreenFrogLoader } from "@/components/ui/FrogLoader";
 import { Trash2, MessageSquareReply, Inbox, Link as LinkIcon } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { toast } from "sonner";
@@ -103,11 +103,7 @@ export default function QnaInbox() {
   };
 
   if (authLoading) {
-    return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <FrogLoader size={24} />
-      </div>
-    );
+    return <FullScreenFrogLoader />;
   }
 
   if (!user) {

--- a/src/pages/QnaPage.tsx
+++ b/src/pages/QnaPage.tsx
@@ -4,7 +4,7 @@ import { Helmet } from "react-helmet-async";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Send, ArrowLeft, CheckCircle, MessageCircle } from "lucide-react";
-import { FrogLoader } from "@/components/ui/FrogLoader";
+import { FrogLoader, FullScreenFrogLoader } from "@/components/ui/FrogLoader";
 import { motion, AnimatePresence } from "framer-motion";
 
 export default function QnaPage() {
@@ -60,11 +60,7 @@ export default function QnaPage() {
   };
 
   if (isLoading) {
-    return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <FrogLoader size={24} />
-      </div>
-    );
+    return <FullScreenFrogLoader />;
   }
 
   if (isError || !profile) {


### PR DESCRIPTION
### Motivation
- Centralize and standardize the app's full-screen loading state to avoid repeated markup and ensure consistent visuals across routes and guards.
- Provide a single reusable component for fullscreen loading so pages and components can switch to it without duplicating layout wrapper code.

### Description
- Added `APP_LOADER_SIZE` constant and exported a new `FullScreenFrogLoader` in `src/components/ui/FrogLoader.tsx` that wraps `FrogLoader` in a full-screen centered container.
- Replaced multiple inline full-screen loading placeholders with `FullScreenFrogLoader` across the app, including `src/App.tsx` (Suspense fallback), `src/components/RequireAdmin.tsx`, and pages: `Index.tsx`, `GameHouseEdit.tsx`, `GameHousePlay.tsx`, `MfaChallengePage.tsx`, `QnaInbox.tsx`, and `QnaPage.tsx`.
- Updated imports where necessary to include `FullScreenFrogLoader` and removed duplicate markup that previously wrapped `FrogLoader` in each file.

### Testing
- Ran TypeScript type-check (`tsc --noEmit`) to validate types and imports, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a195a15a21c8322be733115fb45f340)