### PR TITLE
Improve theming: legacy storage fallback, expanded presets, CSS vars, and boot surface

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,47 @@
   <script>
     (function () {
       const root = document.documentElement;
-      const appearanceKey = 'genjutsu-appearance';
+      const currentStorageKey = 'genjutsu-theme';
+      const legacyStorageKey = 'genjutsu-appearance';
+      const appearanceSuffixes = [
+        'theme', 'preset', 'color', 'customColor', 'font', 'grid', 'radius',
+        'emojiPack', 'animateColor', 'cursorTrail', 'dataSaver', 'soundEnabled', 'shadowWalk'
+      ];
+      const colorPresets = {
+        purple: { light: '270 30% 63%', dark: '270 40% 70%', glowL: '240 10% 3%', glowD: '270 50% 75%' },
+        blue: { light: '220 70% 50%', dark: '220 75% 65%', glowL: '220 70% 50%', glowD: '220 75% 65%' },
+        green: { light: '142 60% 45%', dark: '142 70% 50%', glowL: '142 60% 45%', glowD: '142 70% 50%' },
+        orange: { light: '24 85% 55%', dark: '24 90% 65%', glowL: '24 85% 55%', glowD: '24 90% 65%' },
+        rose: { light: '346 80% 60%', dark: '346 80% 65%', glowL: '346 80% 60%', glowD: '346 80% 65%' },
+        zinc: { light: '240 5% 50%', dark: '240 5% 65%', glowL: '240 5% 50%', glowD: '240 5% 65%' },
+      };
+      const fontFamilies = {
+        'Reddit Mono': "'Reddit Mono', monospace",
+        Inter: "'Inter', sans-serif",
+        'Space Grotesk': "'Space Grotesk', sans-serif",
+        'Fira Code': "'Fira Code', monospace",
+        'JetBrains Mono': "'JetBrains Mono', monospace",
+        'Comic Neue': "'Comic Neue', cursive",
+      };
+      const presetBackgrounds = {
+        default: { light: '270 10% 99%', dark: '240 10% 3.5%' },
+        minecraft: { light: '36 35% 66%', dark: '30 22% 10.5%' },
+        win95: { light: '180 100% 25%', dark: '180 100% 10%' },
+        papyrus: { light: '40 40% 80%', dark: '30 20% 15%' },
+        hackernews: { light: '60 23% 95%', dark: '0 0% 10%' },
+        winxp: { light: '210 100% 98%', dark: '220 40% 8%' },
+        gameboy: { light: '71 85% 40%', dark: '71 85% 40%' },
+        nord: { light: '210 20% 97%', dark: '220 16% 22%' },
+        terminal: { light: '0 0% 0%', dark: '0 0% 0%' },
+      };
+      const radiusPresets = { none: '0px', default: '3px', md: '8px', lg: '16px', full: '2rem' };
+      const allowedThemes = ['dark', 'light', 'system'];
+      const allowedPresets = Object.keys(presetBackgrounds);
+      const allowedColors = Object.keys(colorPresets).concat('custom');
+      const allowedGrids = ['blueprint', 'dotted', 'scanlines', 'none'];
+      const allowedRadii = Object.keys(radiusPresets);
+      const allowedEmojiPacks = ['native', 'twemoji', 'google', 'openmoji'];
+
       const get = (key) => {
         try {
           return localStorage.getItem(key);
@@ -17,29 +57,78 @@
           return null;
         }
       };
+      const hasStoredAppearance = (key) => appearanceSuffixes.some((suffix) => get(`${key}-${suffix}`) !== null);
+      const storageKey = hasStoredAppearance(currentStorageKey) ? currentStorageKey : legacyStorageKey;
+      const getAppearance = (suffix) => get(`${storageKey}-${suffix}`);
+      const oneOf = (value, allowed, fallback) => allowed.indexOf(value) === -1 ? fallback : value;
+      const hexToHsl = (hex) => {
+        const normalized = /^#[0-9a-f]{6}$/i.test(hex || '') ? hex : '#8b5cf6';
+        const r = parseInt(normalized.slice(1, 3), 16) / 255;
+        const g = parseInt(normalized.slice(3, 5), 16) / 255;
+        const b = parseInt(normalized.slice(5, 7), 16) / 255;
+        const max = Math.max(r, g, b);
+        const min = Math.min(r, g, b);
+        let h = 0;
+        let s = 0;
+        const l = (max + min) / 2;
+        if (max !== min) {
+          const d = max - min;
+          s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+          switch (max) {
+            case r: h = ((g - b) / d + (g < b ? 6 : 0)) / 6; break;
+            case g: h = ((b - r) / d + 2) / 6; break;
+            case b: h = ((r - g) / d + 4) / 6; break;
+          }
+        }
+        return `${Math.round(h * 360)} ${Math.round(s * 100)}% ${Math.round(l * 100)}%`;
+      };
 
-      const theme = get(`${appearanceKey}-theme`) || get('genjutsu-theme');
-      const preset = get(`${appearanceKey}-preset`);
-      const grid = get(`${appearanceKey}-grid`);
+      const storedTheme = getAppearance('theme') || get(currentStorageKey);
+      const theme = oneOf(storedTheme, allowedThemes, 'light');
+      const preset = oneOf(getAppearance('preset'), allowedPresets, 'default');
+      const color = oneOf(getAppearance('color'), allowedColors, 'purple');
+      const customColor = getAppearance('customColor') || '#8b5cf6';
+      const font = oneOf(getAppearance('font'), Object.keys(fontFamilies), 'Reddit Mono');
+      const grid = oneOf(getAppearance('grid'), allowedGrids, 'blueprint');
+      const radius = oneOf(getAppearance('radius'), allowedRadii, 'default');
+      const emojiPack = oneOf(getAppearance('emojiPack'), allowedEmojiPacks, 'twemoji');
+      const dataSaver = getAppearance('dataSaver') === 'true';
+      const shadowWalk = getAppearance('shadowWalk') === 'true';
 
       const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      if (theme === 'dark' || (theme !== 'light' && !theme && systemDark) || (theme === 'system' && systemDark)) {
-        root.classList.add('dark');
-      }
+      const activeTheme = theme === 'dark' || (theme === 'system' && systemDark)
+        ? 'dark'
+        : 'light';
+      root.classList.add(activeTheme);
+      root.style.colorScheme = activeTheme;
 
-      if (preset) {
-        root.setAttribute('data-theme-preset', preset);
-      }
+      root.setAttribute('data-theme-preset', preset);
+      root.setAttribute('data-grid', grid);
+      root.setAttribute('data-emoji-pack', emojiPack);
+      root.setAttribute('data-data-saver', String(dataSaver));
+      root.setAttribute('data-shadow-walk', String(shadowWalk));
+      root.style.setProperty('--radius', radiusPresets[radius]);
+      root.style.setProperty('--font-sans', fontFamilies[font]);
+      root.style.setProperty('--font-mono', fontFamilies[font]);
 
-      if (grid) {
-        root.setAttribute('data-grid', grid);
+      const background = presetBackgrounds[preset][activeTheme];
+      root.style.setProperty('--boot-background', `hsl(${background})`);
+
+      if (color === 'custom') {
+        const hsl = hexToHsl(customColor);
+        root.style.setProperty('--primary', hsl);
+        root.style.setProperty('--glow', hsl);
+      } else {
+        const selectedColor = colorPresets[color];
+        root.style.setProperty('--primary', selectedColor[activeTheme]);
+        root.style.setProperty('--glow', activeTheme === 'dark' ? selectedColor.glowD : selectedColor.glowL);
       }
     })();
   </script>
 
   <style>
-    html, body { margin: 0; background: #ffffff; }
-    html.dark body { background: #09090b; }
+    html, body { margin: 0; background: var(--boot-background, #ffffff); }
+    html.dark body { background: var(--boot-background, #09090b); }
   </style>
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -83,9 +172,7 @@
     </main>
   </noscript>
   <div id="root">
-    <div id="boot-loader" style="min-height:100vh;display:flex;align-items:center;justify-content:center;background:inherit;">
-      <img src="/frog-loader.gif" alt="Loading..." width="56" height="56" style="object-fit:contain;mix-blend-mode:multiply;" />
-    </div>
+    <div id="boot-surface" style="min-height:100vh;background:inherit;"></div>
   </div>
   <script type="module" src="/src/main.tsx"></script>
 </body>

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -9,9 +9,10 @@ export type ThemePreset = "default" | "minecraft" | "win95" | "papyrus" | "hacke
 
 /** Convert a hex color (#rrggbb) to an HSL string "H S% L%" suitable for CSS variables. */
 function hexToHsl(hex: string): string {
-    const r = parseInt(hex.slice(1, 3), 16) / 255;
-    const g = parseInt(hex.slice(3, 5), 16) / 255;
-    const b = parseInt(hex.slice(5, 7), 16) / 255;
+    const normalized = /^#[0-9a-f]{6}$/i.test(hex) ? hex : "#8b5cf6";
+    const r = parseInt(normalized.slice(1, 3), 16) / 255;
+    const g = parseInt(normalized.slice(3, 5), 16) / 255;
+    const b = parseInt(normalized.slice(5, 7), 16) / 255;
     const max = Math.max(r, g, b), min = Math.min(r, g, b);
     let h = 0, s = 0;
     const l = (max + min) / 2;
@@ -52,6 +53,27 @@ const fontFamilies = {
     "JetBrains Mono": "'JetBrains Mono', monospace",
     "Comic Neue": "'Comic Neue', cursive",
 };
+
+const legacyStorageKey = "genjutsu-appearance";
+const appearanceSuffixes = [
+    "theme", "preset", "color", "customColor", "font", "grid", "radius",
+    "emojiPack", "animateColor", "cursorTrail", "dataSaver", "soundEnabled", "shadowWalk",
+] as const;
+const themeValues = ["dark", "light", "system"] as const;
+const presetValues = ["default", "minecraft", "win95", "papyrus", "hackernews", "winxp", "gameboy", "nord", "terminal"] as const;
+const colorValues = ["purple", "blue", "green", "orange", "rose", "zinc", "custom"] as const;
+const fontValues = ["Reddit Mono", "Inter", "Space Grotesk", "Fira Code", "JetBrains Mono", "Comic Neue"] as const;
+const gridValues = ["blueprint", "dotted", "scanlines", "none"] as const;
+const radiusValues = ["none", "default", "md", "lg", "full"] as const;
+const emojiPackValues = ["native", "twemoji", "google", "openmoji"] as const;
+
+function oneOf<T extends string>(value: string | null, allowed: readonly T[], fallback: T): T {
+    return value !== null && (allowed as readonly string[]).includes(value) ? (value as T) : fallback;
+}
+
+function hasStoredAppearance(storageKey: string): boolean {
+    return appearanceSuffixes.some((suffix) => safeGetItem(`${storageKey}-${suffix}`) !== null);
+}
 
 type ThemeProviderProps = {
     children: React.ReactNode;
@@ -135,57 +157,47 @@ export function ThemeProvider({
     storageKey = "genjutsu-appearance",
     ...props
 }: ThemeProviderProps) {
+    const initialStorageKey = storageKey === "genjutsu-theme" && !hasStoredAppearance(storageKey) ? legacyStorageKey : storageKey;
+    const getInitialItem = (suffix: string) => safeGetItem(`${initialStorageKey}-${suffix}`);
+
     const [theme, setThemeState] = useState<Theme>(() => {
-        const stored = safeGetItem(`${storageKey}-theme`);
-        return (stored as Theme) || defaultTheme;
+        return oneOf(getInitialItem("theme") || safeGetItem(storageKey), themeValues, defaultTheme);
     });
     const [preset, setPresetState] = useState<ThemePreset>(() => {
-        const stored = safeGetItem(`${storageKey}-preset`);
-        if (stored === "minecraft" || stored === "win95" || stored === "papyrus" || stored === "hackernews" || stored === "winxp" || stored === "gameboy" || stored === "nord" || stored === "terminal") {
-            return stored as ThemePreset;
-        }
-        return "default";
+        return oneOf(getInitialItem("preset"), presetValues, "default");
     });
     const [color, setColorState] = useState<ColorPreset>(() => {
-        return (safeGetItem(`${storageKey}-color`) as ColorPreset) || "purple";
+        return oneOf(getInitialItem("color"), colorValues, "purple");
     });
     const [font, setFontState] = useState<FontPreset>(() => {
-        const stored = safeGetItem(`${storageKey}-font`);
-        if (stored && Object.prototype.hasOwnProperty.call(fontFamilies, stored)) {
-            return stored as FontPreset;
-        }
-        return "Reddit Mono";
+        return oneOf(getInitialItem("font"), fontValues, "Reddit Mono");
     });
     const [grid, setGridState] = useState<GridPreset>(() => {
-        return (safeGetItem(`${storageKey}-grid`) as GridPreset) || "blueprint";
+        return oneOf(getInitialItem("grid"), gridValues, "blueprint");
     });
     const [radius, setRadiusState] = useState<RadiusPreset>(() => {
-        return (safeGetItem(`${storageKey}-radius`) as RadiusPreset) || "default";
+        return oneOf(getInitialItem("radius"), radiusValues, "default");
     });
     const [emojiPack, setEmojiPackState] = useState<EmojiPack>(() => {
-        const stored = safeGetItem(`${storageKey}-emojiPack`);
-        if (stored === "native" || stored === "twemoji" || stored === "google" || stored === "openmoji") {
-            return stored;
-        }
-        return "twemoji";
+        return oneOf(getInitialItem("emojiPack"), emojiPackValues, "twemoji");
     });
     const [customColor, setCustomColorState] = useState<string>(() => {
-        return safeGetItem(`${storageKey}-customColor`) || "#8b5cf6";
+        return getInitialItem("customColor") || "#8b5cf6";
     });
     const [animateColor, setAnimateColorState] = useState<boolean>(() => {
-        return safeGetItem(`${storageKey}-animateColor`) === "true";
+        return getInitialItem("animateColor") === "true";
     });
     const [cursorTrail, setCursorTrailState] = useState<boolean>(() => {
-        return safeGetItem(`${storageKey}-cursorTrail`) === "true";
+        return getInitialItem("cursorTrail") === "true";
     });
     const [dataSaver, setDataSaverState] = useState<boolean>(() => {
-        return safeGetItem(`${storageKey}-dataSaver`) === "true";
+        return getInitialItem("dataSaver") === "true";
     });
     const [soundEnabled, setSoundEnabledState] = useState<boolean>(() => {
-        return safeGetItem(`${storageKey}-soundEnabled`) === "true";
+        return getInitialItem("soundEnabled") === "true";
     });
     const [shadowWalk, setShadowWalkState] = useState<boolean>(() => {
-        return safeGetItem(`${storageKey}-shadowWalk`) === "true";
+        return getInitialItem("shadowWalk") === "true";
     });
 
     const hueRef = useRef<number>(0);
@@ -214,6 +226,7 @@ export function ThemeProvider({
             activeTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
         }
         root.classList.add(activeTheme);
+        root.style.colorScheme = activeTheme;
 
         root.setAttribute("data-theme-preset", preset);
         root.setAttribute("data-grid", grid);


### PR DESCRIPTION
### Motivation
- Migrate and expand the client-side theming system to support more presets, fonts, radii, emoji packs, and feature flags.
- Provide a fallback to the legacy `genjutsu-appearance` storage keys so users keep their saved preferences after renames.
- Simplify initial boot visuals by replacing the inline loader with a neutral boot surface and ensure consistent color-scheme handling across pages.

### Description
- Extended the inline boot script in `index.html` with validated appearance keys, `colorPresets`, `fontFamilies`, `presetBackgrounds`, `radiusPresets`, allowed-value lists, and helper functions like `hexToHsl`, `oneOf`, and `hasStoredAppearance` to safely read and apply settings.
- Added a legacy/current storage detection to prefer stored per-suffix keys (e.g. `genjutsu-theme-color`) and fall back to `genjutsu-appearance-*` when needed, and set corresponding `data-*` attributes and CSS variables (including `--boot-background`, `--primary`, `--glow`, `--radius`, and font vars).
- Reworked theme class handling to always add either `dark` or `light` and set `color-scheme` for improved browser rendering of form controls and scrollbars.
- Replaced the boot loader element (`#boot-loader` with an inline gif) by a neutral `#boot-surface` element in `index.html` and updated styles to use `var(--boot-background)` instead of hardcoded colors.
- Updated `src/components/theme-provider.tsx` to mirror the runtime logic: added `oneOf` and `hasStoredAppearance` helpers, stronger validation for stored values, safe `hexToHsl` normalization, improved initial storage key fallback, and applied `color-scheme` on theme changes.

### Testing
- Performed a TypeScript build and typecheck with `npm run build` (or `tsc`) to validate typings and compilation; the build completed successfully.
- Ran the linter with `npm run lint` to catch formatting/quality issues; linting passed with no errors.
- Started the dev server and exercised theme switching and initial load to verify the new storage fallback and CSS variables were applied as expected; no runtime errors were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a195d62e1ac83229bfb3a78779d3135)