### PR TITLE
Fix frog loader delay and visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,6 +129,8 @@
   <style>
     html, body { margin: 0; background: var(--boot-background, #ffffff); }
     html.dark body { background: var(--boot-background, #09090b); }
+    #boot-loader { mix-blend-mode: multiply; }
+    html.dark #boot-loader { mix-blend-mode: lighten; }
   </style>
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -172,7 +174,9 @@
     </main>
   </noscript>
   <div id="root">
-    <div id="boot-surface" style="min-height:100vh;background:inherit;"></div>
+    <div id="boot-surface" style="min-height:100vh;background:inherit;display:flex;align-items:center;justify-content:center;">
+      <img src="/frog-loader.gif" alt="Loading..." width="56" height="56" id="boot-loader" />
+    </div>
   </div>
   <script type="module" src="/src/main.tsx"></script>
 </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@
 // See the LICENSE file or <https://www.gnu.org/licenses/> for details.
 
 import { lazy, Suspense, useEffect } from "react";
+import { FullScreenFrogLoader } from "@/components/ui/FrogLoader";
 import { MaintenancePage } from "@/components/MaintenancePage";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
@@ -95,7 +96,7 @@ const App = () => {
                   <FloatingWhisperBubble />
                   <PushNotificationPrompt />
                   <Suspense
-                    fallback={<div className="min-h-screen bg-background" />}
+                    fallback={<FullScreenFrogLoader />}
                   >
                     <Routes>
                       <Route path="/" element={<Index />} />


### PR DESCRIPTION
The frog loader was previously only shown after React had initialized and reached certain states, leading to a delay or a white screen on initial load.

This change implements a two-stage loading strategy:
1. **Initial Boot:** A static `<img>` of the frog loader is added directly to `index.html` within the `#boot-surface` div. This ensures it appears as soon as the browser parses the HTML, before any JS is executed. CSS was added to handle `mix-blend-mode` for light and dark themes.
2. **React Suspense:** The empty fallback in `App.tsx`'s `Suspense` component was replaced with `FullScreenFrogLoader`. This ensures the loader remains visible while lazy-loaded components (like the main page routes) are being fetched.

Verified with Playwright screenshots that the loader appears immediately on page load.

---
*PR created automatically by Jules for task [13739599778991345586](https://jules.google.com/task/13739599778991345586) started by @iamovi*