### PR TITLE
Improve chat input area across Whispers, Community, and Stranger chat

### DIFF
--- a/src/components/stranger/StrangerChat.tsx
+++ b/src/components/stranger/StrangerChat.tsx
@@ -7,9 +7,20 @@ import { FrogLoader } from "@/components/ui/FrogLoader";
 export const StrangerChat = () => {
   const { status, messages, sendMessage, startSearch, stopSearch, skip, strangerName, onlineCount, isStrangerTyping, sendTypingIndicator } = useStrangerMatch();
   const [text, setText] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.style.height = "auto";
+      const newHeight = Math.min(textarea.scrollHeight, 120); // Max height of 120px
+      textarea.style.height = `${newHeight}px`;
+      textarea.style.overflowY = textarea.scrollHeight > 120 ? "auto" : "hidden";
+    }
+  }, [text]);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setText(e.target.value);
     
     if (status === 'matched') {
@@ -108,14 +119,21 @@ export const StrangerChat = () => {
                        <span className="hidden sm:inline">Skip</span>
                      </button>
 
-                     <input
-                       type="text"
+                     <textarea
+                       ref={textareaRef}
                        value={text}
                        onChange={handleInputChange}
-                       onKeyDown={(e) => e.key === 'Enter' && handleSend()}
+                       onKeyDown={(e) => {
+                         if (e.key === 'Enter' && !e.shiftKey) {
+                           e.preventDefault();
+                           handleSend();
+                         }
+                       }}
                        placeholder="Type a message..."
-                       className="flex-1 min-w-0 bg-background border-2 border-border rounded-[3px] px-2 sm:px-4 py-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-primary/20 placeholder:text-muted-foreground/50 transition-all font-mono"
+                       className="flex-1 min-w-0 bg-background border-2 border-border rounded-[3px] px-2 sm:px-4 py-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-primary/20 placeholder:text-muted-foreground/50 transition-all font-mono resize-none custom-scrollbar min-h-[38px]"
                        disabled={status !== 'matched'}
+                       rows={1}
+                       enterKeyHint="send"
                      />
                      
                      <button 

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -28,6 +28,7 @@ const ChatPage = () => {
     const { user } = useAuth();
     const navigate = useNavigate();
     const messagesEndRef = useRef<HTMLDivElement>(null);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
     const imageInputRef = useRef<HTMLInputElement>(null);
     const dragDepthRef = useRef(0);
 
@@ -73,6 +74,16 @@ const ChatPage = () => {
     useEffect(() => {
         scrollToBottom();
     }, [messages, isOtherUserTyping]);
+
+    useEffect(() => {
+        const textarea = textareaRef.current;
+        if (textarea) {
+            textarea.style.height = "auto";
+            const newHeight = Math.min(textarea.scrollHeight, 160); // Max height of 160px
+            textarea.style.height = `${newHeight}px`;
+            textarea.style.overflowY = textarea.scrollHeight > 160 ? "auto" : "hidden";
+        }
+    }, [messageText]);
 
     useEffect(() => {
         // Mobile browsers can keep accidental tap-selection during route transitions.
@@ -140,7 +151,7 @@ const ChatPage = () => {
         return { publicUrl: data.publicUrl, filePath };
     };
 
-    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
         const value = e.target.value;
         setMessageText(value);
 
@@ -154,6 +165,13 @@ const ChatPage = () => {
         typingTimeoutRef.current = setTimeout(() => {
             setTyping(false);
         }, 2000);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            handleSend(e as any);
+        }
     };
 
     const handleComposerDragEnter = (e: React.DragEvent<HTMLFormElement>) => {
@@ -436,18 +454,20 @@ const ChatPage = () => {
                             <ImageIcon size={16} />
                         </button>
 
-                        <input
-                            type="text"
+                        <textarea
+                            ref={textareaRef}
                             id="whisper-message-input"
                             name="whisper-message"
                             value={messageText}
                             onChange={handleInputChange}
+                            onKeyDown={handleKeyDown}
                             placeholder="Type a whisper... they vanish in 24h"
-                            className="flex-1 bg-secondary/50 gum-border py-2.5 px-4 outline-none focus:border-primary transition-colors text-sm"
+                            className="flex-1 bg-secondary/50 gum-border py-2.5 px-4 outline-none focus:border-primary transition-colors text-sm resize-none custom-scrollbar min-h-[44px]"
                             autoComplete="off"
                             autoCorrect="off"
                             autoCapitalize="off"
                             spellCheck={false}
+                            rows={1}
                             enterKeyHint="send"
                         />
                         <button

--- a/src/pages/CommunityChat.tsx
+++ b/src/pages/CommunityChat.tsx
@@ -14,9 +14,19 @@ import WhisperLinkPreview from "@/components/WhisperLinkPreview";
 function ChatInputForm({ sendMessage, isSending, user, navigate }: any) {
     const [messageText, setMessageText] = useState("");
     const [showMentionMenu, setShowMentionMenu] = useState(false);
-    const inputRef = useRef<HTMLInputElement>(null);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    useEffect(() => {
+        const textarea = textareaRef.current;
+        if (textarea) {
+            textarea.style.height = "auto";
+            const newHeight = Math.min(textarea.scrollHeight, 160); // Max height of 160px
+            textarea.style.height = `${newHeight}px`;
+            textarea.style.overflowY = textarea.scrollHeight > 160 ? "auto" : "hidden";
+        }
+    }, [messageText]);
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
         const val = e.target.value;
         setMessageText(val);
         
@@ -40,7 +50,7 @@ function ChatInputForm({ sendMessage, isSending, user, navigate }: any) {
         const baseText = messageText.replace(/@(?:ai|a|bot|bo|b)?$/i, "");
         setMessageText(baseText + mention + " ");
         setShowMentionMenu(false);
-        inputRef.current?.focus();
+        textareaRef.current?.focus();
     };
 
     const handleSend = async (e: React.FormEvent) => {
@@ -53,6 +63,13 @@ function ChatInputForm({ sendMessage, isSending, user, navigate }: any) {
             setMessageText("");
         } catch {
             // Error handled in hook
+        }
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === "Enter" && !e.shiftKey && !showMentionMenu) {
+            e.preventDefault();
+            handleSend(e as any);
         }
     };
 
@@ -101,21 +118,22 @@ function ChatInputForm({ sendMessage, isSending, user, navigate }: any) {
 
             {user ? (
                 <form onSubmit={handleSend} autoComplete="off" className="max-w-4xl mx-auto flex gap-3">
-                    <input
-                        type="text"
+                    <textarea
                         id="community-message-input"
                         name="community-message"
-                        ref={inputRef}
+                        ref={textareaRef}
                         value={messageText}
                         onChange={handleInputChange}
+                        onKeyDown={handleKeyDown}
                         placeholder="Say something to the community..."
                         maxLength={500}
-                        className="flex-1 bg-secondary/50 gum-border py-2.5 px-4 outline-none focus:border-primary transition-colors text-sm"
+                        className="flex-1 bg-secondary/50 gum-border py-2.5 px-4 outline-none focus:border-primary transition-colors text-sm resize-none custom-scrollbar min-h-[44px]"
                         autoComplete="off"
                         autoCorrect="off"
                         autoCapitalize="off"
                         spellCheck={false}
-                        enterKeyHint="send"
+                        rows={1}
+                            enterKeyHint="send"
                     />
                     <button
                         type="submit"


### PR DESCRIPTION
Improved the chat input area across the application by replacing the standard text inputs with auto-expanding textareas. This allows for multi-line messages while maintaining the original "gum" aesthetic and user-chosen borders. The new inputs support "Enter" to send and "Shift+Enter" for new lines, providing a more modern chat experience. Changes were applied to `ChatPage.tsx`, `CommunityChat.tsx`, and `StrangerChat.tsx`.

---
*PR created automatically by Jules for task [11245615233193754936](https://jules.google.com/task/11245615233193754936) started by @iamovi*