### PR TITLE
Fix Dark Mode Background Flash

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,8 +127,9 @@
   </script>
 
   <style>
-    html, body { margin: 0; background: var(--boot-background, #ffffff); }
-    html.dark body { background: var(--boot-background, #09090b); }
+    html { margin: 0; background: var(--boot-background, #ffffff); }
+    html.dark { background: var(--boot-background, #09090b); }
+    body { margin: 0; background: transparent; }
     #boot-loader { mix-blend-mode: multiply; }
     html.dark #boot-loader { mix-blend-mode: lighten; }
   </style>
@@ -174,7 +175,7 @@
     </main>
   </noscript>
   <div id="root">
-    <div id="boot-surface" style="min-height:100vh;background:inherit;display:flex;align-items:center;justify-content:center;">
+    <div id="boot-surface" style="min-height:100vh;display:flex;align-items:center;justify-content:center;">
       <img src="/frog-loader.gif" alt="Loading..." width="56" height="56" id="boot-loader" />
     </div>
   </div>


### PR DESCRIPTION
This PR fixes the issue where the background would show as white even in dark mode during the initial boot phase or until a refresh.

The root cause was a CSS specificity conflict:
1. In `index.html`, there was a style: `html.dark body { background: var(--boot-background, #09090b); }`.
2. In `src/index.css`, the app applies theme colors to `body { background-color: hsl(var(--background)); }`.
3. Because `html.dark body` is a more specific selector than just `body`, the boot-time style (which defaults to a generic dark gray) could override the more complex theme-aware backgrounds applied by the React app once it loaded.
4. Additionally, since browsers use the `html` background color to fill the viewport before the `body` is fully painted, setting a base `html` background of white caused a visible flash.

By moving the background application to the `html` element and making the `body` transparent during boot, we ensure the correct color is shown immediately and that the application's CSS can take over cleanly once loaded.

---
*PR created automatically by Jules for task [17931527170475536496](https://jules.google.com/task/17931527170475536496) started by @iamovi*